### PR TITLE
feat: try impl masked mha for sm90a

### DIFF
--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -168,6 +168,17 @@ struct Flash_fwd_params : public Qkv_params {
     
     // Learnable sink
     void *__restrict__ sink_ptr;
+    int * __restrict__ sparse_mask_fine;
+
+    // sparse mask
+    int sparse_mask_k_block_size;
+    int sparse_mask_q_tile_size;
+    int sparse_mask_max_k_blocks;
+
+    int sparse_mask_fine_k_stride;
+    int sparse_mask_fine_q_stride;
+
+    bool use_sparse_mask;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -145,6 +145,10 @@ void set_params_fprop(Flash_fwd_params &params,
     #ifdef FLASHATTENTION_DISABLE_LOCAL
         TORCH_CHECK(!params.is_local, "This flash attention build does not support local attention.");
     #endif
+
+    // Initialize sparse mask to disabled (default)
+    params.use_sparse_mask = false;
+    params.sparse_mask_fine = nullptr;
 }
 
 void set_params_dgrad(Flash_bwd_params &params,
@@ -685,7 +689,8 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         int64_t num_splits,
         std::optional<bool> pack_gqa_,
         int64_t sm_margin,
-        std::optional<const at::Tensor> &sinks_ // (h)
+        std::optional<const at::Tensor> &sinks_, // (h)
+        std::optional<at::Tensor> sparse_mask_fine_   // [total_q, max_k_blocks, num_int32_per_block]
         ) {
 
     auto dprops = at::cuda::getCurrentDeviceProperties();
@@ -1157,6 +1162,39 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     TORCH_CHECK(!k_new_.has_value(), "This flash attention build does not support appending KV.");
     #endif
 
+    // Handle sparse mask for Masked MHA (topk-based sparse attention)
+    if (sparse_mask_fine_.has_value()) {
+        auto sparse_mask_fine = sparse_mask_fine_.value();
+        TORCH_CHECK(sparse_mask_fine.dtype() == torch::kInt32, "sparse_mask_fine must have dtype int32");
+        CHECK_CONTIGUOUS(sparse_mask_fine);
+
+        // sparse_mask_fine: [total_q, max_k_blocks, num_int64_per_block]
+        // Row stride (max_k_blocks * num_int64_per_block) must be multiple of 16 for TMA 128-byte alignment
+        TORCH_CHECK(sparse_mask_fine.dim() == 3, "sparse_mask_fine must be 3D");
+        TORCH_CHECK(sparse_mask_fine.size(0) == total_q, "sparse_mask_fine dim 0 must match total_q");
+        TORCH_CHECK((sparse_mask_fine.size(1) * sparse_mask_fine.size(2) * sizeof(int)) % 128 == 0,
+            "sparse_mask_fine row stride (max_k_blocks * num_int32_per_block * sizeof(int)) must be multiple of 128 for TMA alignment");
+
+        params.use_sparse_mask = true;
+        params.sparse_mask_fine = sparse_mask_fine.data_ptr<int>();
+        params.sparse_mask_max_k_blocks = sparse_mask_fine.size(1);
+        params.sparse_mask_fine_k_stride = sparse_mask_fine.stride(1);
+        params.sparse_mask_fine_q_stride = sparse_mask_fine.stride(0);
+
+        // Get kBlockM and kBlockN from tile_size
+        auto kBlockMN = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local,
+                                           params.is_e4m3 ? 1 : 2, false /*v_colmajor*/, false /*paged_kv_non_TMA*/, params.softcap > 0.f);
+        params.sparse_mask_k_block_size = std::get<1>(kBlockMN);  // kBlockN
+        params.sparse_mask_q_tile_size = std::get<0>(kBlockMN);   // kBlockM
+
+        // Sparse mask constraints
+        TORCH_CHECK(params.arch >= 90, "Sparse mask is only supported on SM90+ (Hopper)");
+        TORCH_CHECK(is_varlen, "Sparse mask requires varlen mode (cu_seqlens_q must be provided)");
+        #ifdef FLASHATTENTION_DISABLE_SPARSE_MASK
+        TORCH_CHECK(false, "This flash attention build does not support sparse mask.");
+        #endif
+    }
+
     if (total_q > 0 && (total_k + params.total_knew) > 0 && num_heads_k > 0) {
         auto stream = at::cuda::getCurrentCUDAStream().stream();
         run_mha_fwd(params, stream);
@@ -1188,6 +1226,43 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
 
     // return {out, softmax_lse};
     return {out, softmax_lse, out_accum, softmax_lse_accum};
+}
+
+
+// Get kBlockM and kBlockN for sparse mask preparation
+// This is needed by the caller to generate masks with the correct block size
+std::tuple<int64_t, int64_t>
+mha_get_tile_size(
+        at::Tensor dummy,  // Dummy tensor for PyTorch dispatcher (not used)
+        int64_t headdim,
+        int64_t headdim_v,
+        at::ScalarType qkv_dtype,
+        bool is_causal,
+        int64_t window_size_left,
+        int64_t window_size_right,
+        bool has_softcap) {
+    (void)dummy;  // Suppress unused parameter warning
+
+    // Compute is_local
+    bool is_local = (window_size_left >= 0 || window_size_right >= 0) && !is_causal;
+
+    // Get element size for tile_size calculation
+    int element_size = (qkv_dtype == at::ScalarType::Float8_e4m3fn) ? 1 : 2;
+
+    // Round up headdim
+    int d_rounded = round_up_headdim(headdim);
+    int dv_rounded = (headdim_v == headdim) ? d_rounded : round_up_headdimv(headdim_v);
+
+    // Get tile sizes from tile_size_fwd_sm90
+    // Note: We use SM90 tile size since sparse mask is only supported on Hopper
+    auto kBlockMN = tile_size_fwd_sm90(d_rounded, dv_rounded, is_causal, is_local,
+                                        element_size, false /*v_colmajor*/,
+                                        false /*paged_kv_non_TMA*/, has_softcap);
+
+    int kBlockM = std::get<0>(kBlockMN);
+    int kBlockN = std::get<1>(kBlockMN);
+
+    return {kBlockM, kBlockN};
 }
 
 #ifdef FLASHATTENTION_DISABLE_BACKWARD

--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -210,6 +210,10 @@ void set_params_fprop(Flash_fwd_params &params,
     #ifdef FLASHATTENTION_DISABLE_LOCAL
         STD_TORCH_CHECK(!params.is_local, "This flash attention build does not support local attention.");
     #endif
+
+    // Initialize sparse mask to disabled (default)
+    params.use_sparse_mask = false;
+    params.sparse_mask_fine = nullptr;
 }
 
 void set_params_dgrad(Flash_bwd_params &params,
@@ -754,7 +758,8 @@ mha_fwd(Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_
         int64_t num_splits,
         std::optional<bool> pack_gqa_,
         int64_t sm_margin,
-        std::optional<const at::Tensor> &sinks_ // (h)
+        std::optional<const at::Tensor> &sinks_, // (h)
+        std::optional<at::Tensor> sparse_mask_fine_   // [total_q, max_k_blocks, num_int32_per_block]
         ) {
 
     auto dprops = get_device_prop();
@@ -1223,6 +1228,40 @@ mha_fwd(Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_
     #ifdef FLASHATTENTION_DISABLE_APPENDKV
     STD_TORCH_CHECK(!k_new_.has_value(), "This flash attention build does not support appending KV.");
     #endif
+
+    // Handle sparse mask for Masked MHA (topk-based sparse attention)
+    if (sparse_mask_fine_.has_value()) {
+        auto sparse_mask_fine = sparse_mask_fine_.value();
+        TORCH_CHECK(sparse_mask_fine.dtype() == torch::kInt32, "sparse_mask_fine must have dtype int32");
+        CHECK_CONTIGUOUS(sparse_mask_fine);
+
+        // sparse_mask_fine: [total_q, max_k_blocks, num_int64_per_block]
+        // Row stride (max_k_blocks * num_int64_per_block) must be multiple of 16 for TMA 128-byte alignment
+        TORCH_CHECK(sparse_mask_fine.dim() == 3, "sparse_mask_fine must be 3D");
+        TORCH_CHECK(sparse_mask_fine.size(0) == total_q, "sparse_mask_fine dim 0 must match total_q");
+        TORCH_CHECK((sparse_mask_fine.size(1) * sparse_mask_fine.size(2) * sizeof(int)) % 128 == 0,
+            "sparse_mask_fine row stride (max_k_blocks * num_int32_per_block * sizeof(int)) must be multiple of 128 for TMA alignment");
+
+        params.use_sparse_mask = true;
+        params.sparse_mask_fine = sparse_mask_fine.data_ptr<int>();
+        params.sparse_mask_max_k_blocks = sparse_mask_fine.size(1);
+        params.sparse_mask_fine_k_stride = sparse_mask_fine.stride(1);
+        params.sparse_mask_fine_q_stride = sparse_mask_fine.stride(0);
+
+        // Get kBlockM and kBlockN from tile_size
+        auto kBlockMN = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local,
+                                           params.is_e4m3 ? 1 : 2, false /*v_colmajor*/, false /*paged_kv_non_TMA*/, params.softcap > 0.f);
+        params.sparse_mask_k_block_size = std::get<1>(kBlockMN);  // kBlockN
+        params.sparse_mask_q_tile_size = std::get<0>(kBlockMN);   // kBlockM
+
+        // Sparse mask constraints
+        TORCH_CHECK(params.arch >= 90, "Sparse mask is only supported on SM90+ (Hopper)");
+        TORCH_CHECK(is_varlen, "Sparse mask requires varlen mode (cu_seqlens_q must be provided)");
+        #ifdef FLASHATTENTION_DISABLE_SPARSE_MASK
+        TORCH_CHECK(false, "This flash attention build does not support sparse mask.");
+        #endif
+    }
+
 
     if (total_q > 0 && (total_k + params.total_knew) > 0 && num_heads_k > 0) {
         auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -77,7 +77,8 @@ def _flash_attn_forward(
     num_splits: int = 1,
     pack_gqa: Optional[bool] = None,
     sm_margin: int = 0,
-    sinks=None,
+    sinks: Optional[torch.Tensor] = None,
+    sparse_mask_fine: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     q, k, k_new, v_new = [maybe_contiguous(x) for x in (q, k, k_new, v_new)]
     v = v.contiguous() if v.stride(-1) != 1 and v.stride(-3) != 1 else v
@@ -90,6 +91,7 @@ def _flash_attn_forward(
     ]
     rotary_cos, rotary_sin = [maybe_contiguous(x) for x in (rotary_cos, rotary_sin)]
     seqlens_rotary = maybe_contiguous(seqlens_rotary)
+    sparse_mask_fine = maybe_contiguous(sparse_mask_fine)
     out, softmax_lse, out_accum, softmax_lse_accum = flash_attn_3_cuda.fwd(
         q,
         k,
@@ -126,6 +128,7 @@ def _flash_attn_forward(
         pack_gqa,
         sm_margin,
         sinks,
+        sparse_mask_fine
     )
 
     if out_accum is None:
@@ -173,6 +176,8 @@ def _flash_attn_forward_fake(
     num_splits: int = 1,
     pack_gqa: Optional[bool] = None,
     sm_margin: int = 0,
+    sinks: Optional[List[torch.Tensor]] = None,
+    sparse_mask_fine: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Symbolic fake implementation of flash attention forward.
@@ -557,6 +562,7 @@ class FlashAttnFunc(torch.autograd.Function):
         sm_margin=0,
         return_softmax=False,
         sinks=None,
+        sparse_mask_fine=None
     ):
         if softmax_scale is None:
             softmax_scale = (q.shape[-1] + (qv.shape[-1] if qv is not None else 0)) ** (-0.5)
@@ -584,6 +590,7 @@ class FlashAttnFunc(torch.autograd.Function):
             pack_gqa=pack_gqa,
             sm_margin=sm_margin,
             sinks=sinks,
+            sparse_mask_fine=sparse_mask_fine,
         )
         # ctx.save_for_backward(q, k, v, out_padded, softmax_lse)
         ctx.save_for_backward(q, k, v, out, softmax_lse)
@@ -655,6 +662,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         sm_margin=0,
         return_softmax=False,
         sinks=None,
+        sparse_mask_fine: Optional[torch.Tensor] = None,
     ):
         if softmax_scale is None:
             softmax_scale = (q.shape[-1] + (qv.shape[-1] if qv is not None else 0)) ** (-0.5)
@@ -686,6 +694,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             pack_gqa=pack_gqa,
             sm_margin=sm_margin,
             sinks=sinks,
+            sparse_mask_fine=sparse_mask_fine,
         )
         # ctx.save_for_backward(q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
         ctx.save_for_backward(q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
@@ -814,6 +823,7 @@ def flash_attn_func(
     sm_margin=0,
     return_attn_probs=False,
     sinks=None,
+    sparse_mask_fine=None
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
@@ -877,6 +887,7 @@ def flash_attn_func(
         sm_margin,
         return_attn_probs,
         sinks,
+        sparse_mask_fine,
     )
 
 
@@ -903,6 +914,7 @@ def flash_attn_varlen_func(
     sm_margin=0,
     return_attn_probs=False,
     sinks=None,
+    sparse_mask_fine: Optional[torch.Tensor] = None,
 ):
     return FlashAttnVarlenFunc.apply(
         q,
@@ -927,6 +939,7 @@ def flash_attn_varlen_func(
         sm_margin,
         return_attn_probs,
         sinks,
+        sparse_mask_fine
     )
 
 
@@ -966,6 +979,7 @@ def flash_attn_with_kvcache(
     sm_margin=0,     # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
+    sparse_mask_fine: Optional[torch.Tensor] = None
 ):
     """
     If k and v are not None, k_cache and v_cache will be updated *inplace* with the new values from
@@ -1061,6 +1075,8 @@ def flash_attn_with_kvcache(
             (q.shape[0],), cache_seqlens, dtype=torch.int32, device=k_cache.device
         )
         cache_seqlens = maybe_contiguous(cache_seqlens)
+    # If sparse_mask is provided, set causal=False (mask handles causality)
+    effective_causal = causal if sparse_mask_fine is None else False
     out, softmax_lse, *rest = _flash_attn_forward(
         q,
         k_cache,
@@ -1084,7 +1100,7 @@ def flash_attn_with_kvcache(
         rotary_seqlens,
         q_descale, k_descale, v_descale,
         softmax_scale,
-        causal=causal,
+        causal=effective_causal,
         window_size_left=window_size[0],
         window_size_right=window_size[1],
         attention_chunk=attention_chunk,
@@ -1095,6 +1111,7 @@ def flash_attn_with_kvcache(
         pack_gqa=pack_gqa,
         sm_margin=sm_margin,
         sinks=sinks,
+        sparse_mask_fine=sparse_mask_fine
     )
     # return (out, softmax_lse) if return_softmax_lse else out
     return (out, softmax_lse, *rest) if return_softmax_lse else out
@@ -1141,3 +1158,55 @@ def get_scheduler_metadata(
         sm_margin,
     )
     return scheduler_metadata
+
+def get_tile_size(
+    headdim: int,
+    headdim_v: Optional[int] = None,
+    qkv_dtype: torch.dtype = torch.bfloat16,
+    is_causal: bool = False,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
+    has_softcap: bool = False,
+) -> Tuple[int, int]:
+    """
+    Query the tile size (kBlockM, kBlockN) that FlashAttention will use for the given configuration.
+
+    This is essential for generating correctly shaped sparse masks for flash_attn_varlen_func_sparse.
+    The mask shapes depend on kBlockM and kBlockN (for K-block
+    granularity and bitmap alignment).
+
+    Arguments:
+        headdim: int. Head dimension for Q/K.
+        headdim_v: int. Head dimension for V. Default to headdim if None.
+        qkv_dtype: torch.dtype. Data type (torch.float16, torch.bfloat16, torch.float8_e4m3fn).
+        is_causal: bool. Whether causal attention is used.
+        window_size_left: int. Left window size for local attention (-1 = infinite).
+        window_size_right: int. Right window size for local attention (-1 = infinite).
+        has_softcap: bool. Whether softcapping is enabled.
+
+    Returns:
+        Tuple[int, int]: (kBlockM, kBlockN) tile sizes.
+
+    Example:
+        >>> kBlockM, kBlockN = get_tile_size(headdim=192, headdim_v=128, qkv_dtype=torch.bfloat16)
+        >>> print(kBlockM, kBlockN)  # Expected: 128, 128
+        >>>
+        >>> # Use these to compute mask shapes
+        >>> num_int64_per_block = (kBlockN + 63) // 64  # = 2 for kBlockN=128
+        >>> max_k_blocks = (max_seqlen_k + kBlockN - 1) // kBlockN
+        >>> num_q_tiles = (total_q + kBlockM - 1) // kBlockM
+    """
+    # Create a dummy CUDA tensor to trigger PyTorch dispatcher to route to CUDA backend.
+    # This tensor is not actually used, it just helps dispatcher determine the backend.
+    dummy_tensor = torch.empty(0, device="cuda", dtype=qkv_dtype)
+
+    return flash_attn_3_cuda.get_tile_size(
+        dummy_tensor,
+        headdim,
+        headdim_v if headdim_v is not None else headdim,
+        qkv_dtype,
+        is_causal,
+        window_size_left,
+        window_size_right,
+        has_softcap,
+    )

--- a/hopper/flash_fwd_kernel_sm90.h
+++ b/hopper/flash_fwd_kernel_sm90.h
@@ -50,6 +50,7 @@ public:
     static constexpr int NumProducerThreads = CollectiveMainloop::NumProducerThreads;
     static constexpr bool SameHeadDim = CollectiveMainloop::SameHeadDim;
     static constexpr bool LargeHeadDimV = CollectiveMainloop::LargeHeadDimV;
+    static constexpr bool Has_sparse_mask = CollectiveMainloop::Has_sparse_mask;
     static_assert(CollectiveMainloop::LargeHeadDimV == CollectiveEpilogue::LargeHeadDimV);
     using SeqlenInfo_t = typename CollectiveMainloop::SeqlenInfo_t;
 
@@ -83,8 +84,8 @@ public:
 
     /// Register requirement for Load and Math WGs
     // If we use cp.async to load K and V, we need more registers for the producer WG.
-    static constexpr uint32_t LoadRegisterRequirement = NumMmaWarpGroups == 1 ? 56 : (NumMmaWarpGroups == 2 ? (Use_TMA_KV ? 24 : 40) : 32);
-    static constexpr uint32_t MmaRegisterRequirement = NumMmaWarpGroups == 1 ? 256 : (NumMmaWarpGroups == 2 ? (Use_TMA_KV ? 240 : 232) : 160);
+    static constexpr uint32_t LoadRegisterRequirement = (NumMmaWarpGroups == 1 ? 56 : (NumMmaWarpGroups == 2 ? ((Use_TMA_KV) ? 24 : 40) : 32));
+    static constexpr uint32_t MmaRegisterRequirement = (NumMmaWarpGroups == 1 ? 256 : (NumMmaWarpGroups == 2 ? ((Use_TMA_KV) ? 240 : 232) : 160));
     // If you want to print from the producer warp, you'd need to increase the number of registers
     // Otherwise you'll get CUDA error.
     // static constexpr uint32_t LoadRegisterRequirement = 40;
@@ -116,6 +117,7 @@ public:
             alignas(16) typename CollectiveMainloop::MainloopPipelineKVNew::SharedStorage pipeline_k_new;
             alignas(16) typename CollectiveMainloop::MainloopPipelineKVNew::SharedStorage pipeline_v_new;
             alignas(16) typename TileScheduler::SharedStorage smem_scheduler;
+            alignas(16) typename CollectiveMainloop::MainloopPipelineMask::SharedStorage pipeline_mask;
         } pipelines;
 
     };
@@ -190,11 +192,13 @@ public:
         using MainloopPipelineV = typename CollectiveMainloop::MainloopPipelineV;
         using MainloopPipelineVt = typename CollectiveMainloop::MainloopPipelineVt;
         using MainloopPipelineKVNew = typename CollectiveMainloop::MainloopPipelineKVNew;
+        using MainloopPipelineMask = typename CollectiveMainloop::MainloopPipelineMask;
         using PipelineState = typename CollectiveMainloop::PipelineState;
         using PipelineParamsK = typename MainloopPipelineK::Params;
         using PipelineParamsV = typename MainloopPipelineV::Params;
         using PipelineParamsVt = typename MainloopPipelineVt::Params;
         using PipelineParamsKVNew = typename MainloopPipelineKVNew::Params;
+        using PipelineParamsMask = typename MainloopPipelineMask::Params;
 
         SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
@@ -233,6 +237,20 @@ public:
             pipeline_params_k.producer_arv_count = NumProducerThreads;
         }
 
+        // mask pipeline params: TMA path uses transaction_bytes, cp.async path uses arv_count
+        PipelineParamsMask pipeline_params_mask;
+        pipeline_params_mask.role = warp_group_idx == 0
+            ? MainloopPipelineMask::ThreadCategory::Producer
+            : MainloopPipelineMask::ThreadCategory::Consumer;
+        if constexpr (CollectiveMainloop::Use_TMA_Mask) {
+            pipeline_params_mask.transaction_bytes = CollectiveMainloop::TmaTransactionBytesMask;
+            pipeline_params_mask.is_leader = warp_group_thread_idx == 0;
+            pipeline_params_mask.num_consumers = !LargeHeadDimV ? NumMmaThreads : cutlass::NumThreadsPerWarpGroup;
+        } else {
+            pipeline_params_mask.consumer_arv_count = !LargeHeadDimV ? NumMmaThreads : cutlass::NumThreadsPerWarpGroup;
+            pipeline_params_mask.producer_arv_count = NumProducerThreads;
+        }
+
         static_assert(is_same_v<PipelineParamsK, PipelineParamsVt>);
         PipelineParamsVt pipeline_params_vt = pipeline_params_k;
         if constexpr (Use_TMA_KV && !SameHeadDim) {
@@ -247,6 +265,13 @@ public:
                 return MainloopPipelineK(shared_storage.pipelines.pipeline_k, pipeline_params_k, ClusterShape{});
             } else {
                 return MainloopPipelineK(shared_storage.pipelines.pipeline_k, pipeline_params_k);
+            }
+        }();
+        MainloopPipelineMask pipeline_mask = [&] {
+            if constexpr (CollectiveMainloop::Use_TMA_Mask) {
+                return MainloopPipelineMask(shared_storage.pipelines.pipeline_mask, pipeline_params_mask, ClusterShape{});
+            } else {
+                return MainloopPipelineMask(shared_storage.pipelines.pipeline_mask, pipeline_params_mask);
             }
         }();
         // MainloopPipelineV pipeline_v(shared_storage.pipelines.pipeline_v, pipeline_params_v, ClusterShape{});
@@ -369,10 +394,10 @@ public:
                     scheduler.prefetch_next_work(params.scheduler, work_tile_info);
                 };
                 // pipeline_vt won't be used if we don't need to transpose V.
-                mainloop.load(params.mainloop, pipeline_k, pipeline_v, pipeline_vt, smem_pipe_write,
+                mainloop.load(params.mainloop, pipeline_k, pipeline_v, pipeline_vt, pipeline_mask, smem_pipe_write,
                                          shared_storage, scheduler_prefetch, seqlen_info, block_coord, work_idx);
             }
-            mainloop.load_tail(pipeline_k, pipeline_v, pipeline_vt, smem_pipe_write, shared_storage, work_idx);
+            mainloop.load_tail(pipeline_k, pipeline_v, pipeline_vt, pipeline_mask, smem_pipe_write, shared_storage, work_idx);
         } else {  // Consumer
             cutlass::arch::warpgroup_reg_alloc<MmaRegisterRequirement>();
 
@@ -461,12 +486,12 @@ public:
                 bool tile_valid;
                 if constexpr (!LargeHeadDimV) {
                     tile_valid = mainloop.mma(
-                        params.mainloop, pipeline_k, pipeline_v, smem_pipe_read,
+                        params.mainloop, pipeline_k, pipeline_v, pipeline_mask, smem_pipe_read,
                         tOrO, softmax, threadIdx.x - MmaThreadOffset, work_idx, seqlen_info, block_coord, shared_storage);
                 } else {  // mma_pv might not compile if !LargeHeadDimV
                     if (warp_group_idx == 1) {
                         tile_valid = mainloop.mma(
-                            params.mainloop, pipeline_k, pipeline_v, smem_pipe_read,
+                            params.mainloop, pipeline_k, pipeline_v, pipeline_mask, smem_pipe_read,
                             tOrO, softmax, threadIdx.x - MmaThreadOffset, work_idx, seqlen_info, block_coord, shared_storage);
                     } else {
                         tile_valid = mainloop.mma_pv(

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -26,7 +26,7 @@ using namespace cute;
 
 template <int Arch, int kHeadDim, int kHeadDimV, int ClusterM, typename Element, typename ElementOut,
           bool Is_causal, bool Is_local, bool Has_softcap, bool Varlen, bool PagedKVNonTMA, bool AppendKV, bool HasQv,
-          bool PackGQA, bool Split, bool V_colmajor>
+          bool PackGQA, bool Split, bool V_colmajor, bool Has_sparse_mask=false>
 void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     static_assert(!(Is_causal && Is_local), "Causal and Local cannot be enabled at the same time");
     static_assert(!(AppendKV && V_colmajor), "AppendKV and V_colmajor cannot be enabled at the same time");
@@ -52,7 +52,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     using ClusterShape = cute::Shape<Int<ClusterM>, _1, _1>;
     using CollectiveMainloop = std::conditional_t<
         Arch >= 90,
-        flash::CollectiveMainloopFwdSm90<kStages, ClusterShape, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm90, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, HasQv, MmaPV_is_RS, IntraWGOverlap, PackGQA, Split, V_colmajor, ElementSink>,
+        flash::CollectiveMainloopFwdSm90<kStages, ClusterShape, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm90, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, HasQv, MmaPV_is_RS, IntraWGOverlap, PackGQA, Split, V_colmajor, ElementSink, Has_sparse_mask>,
         flash::CollectiveMainloopFwdSm80<kNWarps, kStages, Q_in_regs, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm80, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, PackGQA, Split, ElementSink>
     >;
     using CollectiveEpilogue = flash::CollectiveEpilogueFwd<TileShape_MNK_PV, ClusterShape, ElementOut, ArchTag, CollectiveMainloop::NumMmaThreads, Varlen, PackGQA, Split, FP8_TransposeV>;
@@ -131,6 +131,12 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
         params.seqused_q, params.seqused_k,
         params.leftpad_k, params.seqlens_rotary,
         static_cast<ElementSink const*>(params.sink_ptr),
+        // Sparse Mask for Masked MHA (topk-based sparse attention)
+        params.sparse_mask_fine,
+        params.sparse_mask_max_k_blocks,
+        params.sparse_mask_fine_q_stride,
+        params.sparse_mask_fine_k_stride,
+        params.total_q
     };
     typename CollectiveEpilogue::Arguments epilogue_args {
         static_cast<ElementOut*>(params.o_ptr),
@@ -218,7 +224,11 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
                         // Only use Cluster if number of tiles along seqlen_q is even and not varlen
                         CLUSTER_SWITCH(cutlass::ceil_div(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k), kBlockM) % 2 == 0, Use_cluster, [&] {
                             static constexpr int ClusterM = Enable_cluster && Use_cluster ? 2 : 1;
-                            run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor>(params, stream);
+                            // Sparse mask is only supported on SM90+ and requires Varlen mode
+                            // When Has_sparse_mask is true, causal/local masks are bypassed (handled by sparse mask)
+                            SPARSE_MASK_SWITCH(params.use_sparse_mask && Arch >= 90 && Varlen, Has_sparse_mask, [&] {
+                                run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor, Has_sparse_mask>(params, stream);
+                            });
                         });
                     });
                 });

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -30,7 +30,7 @@ using namespace cute;
 
 template <int Stages, class ClusterShape_, class TileShape_MNK_, int kHeadDimV, class Element_, class ElementAccum_, class ArchTag_,
         bool Is_causal_, bool Is_local_, bool Has_softcap_, bool Varlen_, bool PagedKVNonTMA_, bool AppendKV_, bool HasQv_,
-        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_>
+        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_, bool Has_sparse_mask_=false>
 struct CollectiveMainloopFwdSm90 {
 
     static constexpr int kStages = Stages;
@@ -53,6 +53,7 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr bool PackGQA = PackGQA_;
     static constexpr bool Split = Split_;
     static constexpr bool V_colmajor = V_colmajor_;
+    static constexpr bool Has_sparse_mask = Has_sparse_mask_;
     static constexpr bool Transpose_V = Is_FP8 && !V_colmajor;
     static constexpr bool Use_TMA_Q = !PackGQA;
     static constexpr bool Use_TMA_KV = !PagedKVNonTMA;
@@ -69,6 +70,7 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr int kBlockM = get<0>(TileShape_MNK{});
     static constexpr int kBlockN = get<1>(TileShape_MNK{});
     static constexpr int kHeadDim = get<2>(TileShape_MNK{});
+    static constexpr int kNumInt32PerBlock = (kBlockN + 31) / 32;
 
     using SeqlenInfo_t = flash::SeqlenInfoQKNewK<Varlen, AppendKV>;
     using BlockMN_t = flash::BlockMN<SeqlenInfo_t, kBlockM, kBlockN, Is_causal, Is_local, PackGQA, Split>;
@@ -277,16 +279,37 @@ struct CollectiveMainloopFwdSm90 {
         ClusterShape{}));
     using TMA_Qv = std::conditional_t<HasQv, TMA_Qv_, std::nullptr_t>;
 
+    // Mask shape: (total_q, max_k_blocks * num_int32_per_block)
+    using ShapeMask = cute::Shape<int32_t, int32_t>;
+    using StrideMask = cute::Stride<int64_t, _1>;
+    // Simple row-major layout for mask in smem: (kBlockM, kNumInt32PerBlock, kStages)
+    using SmemLayoutMask = Layout<Shape<Int<kBlockM>, Int<kNumInt32PerBlock>, Int<kStages>>,
+                                   Stride<Int<kNumInt32PerBlock>, _1, Int<kBlockM * kNumInt32PerBlock>>>;
+    using TMA_Mask_ = decltype(make_tma_copy(
+        SM90_TMA_LOAD{},
+        make_tensor(make_gmem_ptr(static_cast<int32_t const*>(nullptr)), ShapeMask{}, StrideMask{}),
+        take<0, 2>(SmemLayoutMask{}),
+        Shape<Int<kBlockM>, Int<kNumInt32PerBlock>>{},
+        _1{}));
+    using TMA_Mask = std::conditional_t<Has_sparse_mask && Use_TMA_KV, TMA_Mask_, std::nullptr_t>;
+
     // Set the bytes transferred in this TMA transaction (may involve multiple issues)
     static constexpr uint32_t TmaTransactionBytesQ = static_cast<uint32_t>(size(SmemLayoutQ{}) * cutlass::sizeof_bits_v<Element> / 8);
     static constexpr uint32_t TmaTransactionBytesK = static_cast<uint32_t>(size(take<0, 2>(SmemLayoutK{})) * cutlass::sizeof_bits_v<Element> / 8);
     static constexpr uint32_t TmaTransactionBytesV = static_cast<uint32_t>(size(take<0, 2>(SmemLayoutVt{})) * cutlass::sizeof_bits_v<Element> / 8);
     static constexpr uint32_t TmaTransactionBytesQv = static_cast<uint32_t>(size(SmemLayoutQv{}) * cutlass::sizeof_bits_v<Element> / 8);
+    static constexpr uint32_t TmaTransactionBytesMask = static_cast<uint32_t>(kBlockM * kNumInt32PerBlock * sizeof(int));
+
+    // Whether to use TMA for loading mask (same condition as K/V TMA)
+    static constexpr bool Use_TMA_Mask = Use_TMA_KV && Has_sparse_mask;
 
     using PipelineTmaAsync = std::conditional_t<CUTE_STATIC_V(size(ClusterShape{})) == 1, typename cutlass::PipelineTmaAsyncNoCluster<kStages>, typename cutlass::PipelineTmaAsync<kStages>>;
+    // For mask, we don't need cluster multicast, so always use PipelineTmaAsyncNoCluster
+    using PipelineTmaAsyncMask = typename cutlass::PipelineTmaAsyncNoCluster<kStages>;
     using MainloopPipelineK = std::conditional_t<Use_TMA_KV, PipelineTmaAsync, typename cutlass::PipelineAsync<kStages>>;
     using MainloopPipelineV = std::conditional_t<!Transpose_V && Use_TMA_KV, PipelineTmaAsync, typename cutlass::PipelineAsync<kStages>>;
     using MainloopPipelineVt = std::conditional_t<Use_TMA_KV, PipelineTmaAsync, typename cutlass::PipelineAsync<kStages>>;
+    using MainloopPipelineMask = std::conditional_t<Use_TMA_Mask, PipelineTmaAsyncMask, typename cutlass::PipelineAsync<kStages>>;
     // We always use TMA for K_new and V_new
     using MainloopPipelineKVNew = PipelineTmaAsync;
     using PipelineState = cutlass::PipelineState<kStages>;
@@ -305,6 +328,7 @@ struct CollectiveMainloopFwdSm90 {
     using SmemP_t = std::conditional_t<MmaPV_is_RS, cute::array<Element, 0>, cute::array_aligned<Element, cute::cosize_v<SmemLayoutP>, SmemAlignmentP>>;
     using SmemScale_t = std::conditional_t<!LargeHeadDimV, cute::array<float, 0>, cute::array_aligned<float, cute::cosize_v<SmemLayoutScale>, 128>>;
     using SmemQv_t = std::conditional_t<!HasQv, cute::array<Element, 0>, cute::array_aligned<Element, cute::cosize_v<SmemLayoutQv>, SmemAlignmentQv>>;
+    using SmemMask_t = std::conditional_t<!Has_sparse_mask, cute::array<int, 0>, cute::array_aligned<int, kStages * kBlockM * kNumInt32PerBlock, 128>>;
     // Sometimes even with SmemP_t = cute::array<Element, 0>, putting it in the TensorStorage struct causes
     // smem size to go from 227KB to 228KB and we get "invalid argument".
 
@@ -314,6 +338,7 @@ struct CollectiveMainloopFwdSm90 {
         cute::array_aligned<Element, cute::cosize_v<SmemLayoutK>, SmemAlignmentK> smem_k;
         SmemQv_t smem_qv;
         cute::array_aligned<ElementSink, cute::cosize_v<SmemLayoutSink>, 128> smem_sink;
+        SmemMask_t smem_mask;
     };
 
     struct TensorStorageWithPNoTranspose : cute::aligned_struct<cute::max(SmemAlignmentQ, SmemAlignmentK, SmemAlignmentVtNoTranspose, SmemAlignmentP), _0> {
@@ -323,6 +348,7 @@ struct CollectiveMainloopFwdSm90 {
         SmemQv_t smem_qv;
         SmemP_t smem_p;
         cute::array_aligned<ElementSink, cute::cosize_v<SmemLayoutSink>, 128> smem_sink;
+        SmemMask_t smem_mask;
     };
     struct TensorStorageWithPScaleNoTranspose : cute::aligned_struct<cute::max(SmemAlignmentQ, SmemAlignmentK, SmemAlignmentVtNoTranspose, SmemAlignmentP), _0> {
         cute::array_aligned<Element, cute::cosize_v<SmemLayoutVt>, SmemAlignmentVtNoTranspose> smem_v;
@@ -332,6 +358,7 @@ struct CollectiveMainloopFwdSm90 {
         SmemP_t smem_p;
         SmemScale_t smem_scale;
         cute::array_aligned<ElementSink, cute::cosize_v<SmemLayoutSink>, 128> smem_sink;
+        SmemMask_t smem_mask;
     };
 
     using TensorStorageNoTranspose = std::conditional_t<
@@ -351,6 +378,7 @@ struct CollectiveMainloopFwdSm90 {
         SmemQv_t smem_qv;
         SmemScale_t smem_scale;
         cute::array_aligned<ElementSink, cute::cosize_v<SmemLayoutSink>, 128> smem_sink;
+        SmemMask_t smem_mask;
     };
 
     using TensorStorage = std::conditional_t<!Transpose_V, TensorStorageNoTranspose, TensorStorageTransposeV>;
@@ -404,6 +432,11 @@ struct CollectiveMainloopFwdSm90 {
         int const* const leftpad_k = nullptr;
         int const* const seqlens_rotary = nullptr;
         ElementSink const* const ptr_sink = nullptr;
+        int const* sparse_mask_fine = nullptr;       // [total_q, max_k_blocks, num_int32_per_block] bitmap
+        int sparse_mask_max_k_blocks = 0;            // ceil(max_seqlen_k / kBlockN)
+        int sparse_mask_fine_q_stride = 0;           // = max_k_blocks * num_int32_per_block
+        int sparse_mask_fine_k_stride = 0;           // = num_int32_per_block
+        int total_q = 0;                             // total number of Q positions (for TMA Mask)
     };
 
     // Device side kernel params
@@ -446,6 +479,7 @@ struct CollectiveMainloopFwdSm90 {
         TMA_K tma_load_K_new;
         TMA_V tma_load_V_new;
         TMA_Qv tma_load_Qv;
+        TMA_Mask tma_load_Mask;
         float const softmax_scale_log2;
         float const* ptr_q_descale, *ptr_k_descale, *ptr_v_descale;
         StrideDescale const stride_q_descale, stride_k_descale, stride_v_descale;
@@ -462,6 +496,11 @@ struct CollectiveMainloopFwdSm90 {
         int const* const leftpad_k = nullptr;
         int const *const seqlens_rotary = nullptr;
         ElementSink const* const ptr_sink = nullptr;
+        int const* sparse_mask_fine = nullptr;              // [total_q, max_k_blocks, num_int32_per_block] bitmap
+        int sparse_mask_max_k_blocks = 0;                   // ceil(max_seqlen_k / kBlockN)
+        int sparse_mask_fine_q_stride = 0;                  // = max_k_blocks * num_int32_per_block
+        int sparse_mask_fine_k_stride = 0;                  // = num_int32_per_block
+        int total_q = 0;                                    // total number of Q positions (for TMA Mask)
     };
 
     static Params
@@ -519,6 +558,27 @@ struct CollectiveMainloopFwdSm90 {
                 return nullptr;
             }
         }();
+        // Create TMA descriptor for mask if Has_sparse_mask and Use_TMA_KV
+        TMA_Mask tma_load_Mask = [&] {
+            if constexpr (Has_sparse_mask && Use_TMA_KV) {
+                // Mask shape: (total_q, max_k_blocks * num_int32_per_block)
+                // total_q is the first dimension, sparse_mask_fine_q_stride is the row stride
+                auto shape_Mask = make_shape(
+                    static_cast<int32_t>(args.total_q),                      // total_q rows
+                    static_cast<int32_t>(args.sparse_mask_fine_q_stride)     // max_k_blocks * num_int32_per_block cols
+                );
+                auto stride_Mask = make_stride(args.sparse_mask_fine_q_stride, Int<1>{});
+                Tensor mMask = make_tensor(make_gmem_ptr(args.sparse_mask_fine), shape_Mask, stride_Mask);
+                return make_tma_copy(
+                    SM90_TMA_LOAD{},
+                    mMask,
+                    take<0, 2>(SmemLayoutMask{}),
+                    Shape<Int<kBlockM>, Int<kNumInt32PerBlock>>{},
+                    _1{});  // no multicast for mask
+            } else {
+                return nullptr;
+            }
+        }();
         // If PackGQA, reshape Q to be ((qhead_per_khead, seqlen_q), head_size, nhead_k, batch_size)
         int const qhead_per_khead = !PackGQA ? 1 : cute::ceil_div(get<2>(args.shape_Q), get<2>(args.shape_K));
         auto const shape_Q_packed = cute::conditional_return<!PackGQA>(
@@ -564,7 +624,7 @@ struct CollectiveMainloopFwdSm90 {
                 cutlass::FastDivmod(page_size),  // page_size_divmod
                 cutlass::FastDivmod(!args.ptr_pagetable ? 1 : cute::ceil_div(page_size, kBlockN)),  // blockN_per_page_size_divmod
                 cutlass::FastDivmod(cute::ceil_div(get<2>(args.shape_Q), get<2>(args.shape_K))),
-                tma_load_Q, tma_load_K, tma_load_V, tma_load_K_new, tma_load_V_new, tma_load_Qv,
+                tma_load_Q, tma_load_K, tma_load_V, tma_load_K_new, tma_load_V_new, tma_load_Qv, tma_load_Mask,
                 !Has_softcap ? float(args.softmax_scale * M_LOG2E) : float(args.softcap_val * M_LOG2E),
                 args.ptr_q_descale, args.ptr_k_descale, args.ptr_v_descale,
                 args.stride_q_descale, args.stride_k_descale, args.stride_v_descale,
@@ -573,7 +633,11 @@ struct CollectiveMainloopFwdSm90 {
                 !Split ? 1 : args.num_splits,
                 args.kv_batch_idx,
                 args.cu_seqlens_q, args.cu_seqlens_k, args.cu_seqlens_k_new,
-                args.seqused_q, args.seqused_k, args.leftpad_k, args.seqlens_rotary, args.ptr_sink};
+                args.seqused_q, args.seqused_k, args.leftpad_k, args.seqlens_rotary, args.ptr_sink,
+                args.sparse_mask_fine,
+                args.sparse_mask_max_k_blocks,
+                args.sparse_mask_fine_q_stride, args.sparse_mask_fine_k_stride,
+            };
     }
 
     /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
@@ -593,6 +657,9 @@ struct CollectiveMainloopFwdSm90 {
             cute::prefetch_tma_descriptor(params.tma_load_K_new.get_tma_descriptor());
             cute::prefetch_tma_descriptor(params.tma_load_V_new.get_tma_descriptor());
         }
+        if constexpr (Use_TMA_Mask) {
+            cute::prefetch_tma_descriptor(params.tma_load_Mask.get_tma_descriptor());
+        }
     }
 
     template <typename SchedulerPrefetch, typename SharedStorage>
@@ -601,6 +668,7 @@ struct CollectiveMainloopFwdSm90 {
          MainloopPipelineK pipeline_k,
          MainloopPipelineV pipeline_v,
          MainloopPipelineVt pipeline_vt,
+         MainloopPipelineMask pipeline_mask,
          PipelineState& smem_pipe_write,
          SharedStorage &shared_storage,
          SchedulerPrefetch const& scheduler_prefetch,
@@ -755,6 +823,79 @@ struct CollectiveMainloopFwdSm90 {
             }
         }
 
+        // Set up TMA for Mask loading
+        Tensor sMask = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_mask.data()), SmemLayoutMask{});
+        auto tMaskgMask_tMasksMask_tuple = [&] {
+            if constexpr (Use_TMA_Mask) {
+                // For TMA, we create tensor views using the TMA descriptor
+                // The mask is laid out as (total_q, max_k_blocks * num_int32_per_block) in gmem
+                // We load tile of (kBlockM, kNumInt32PerBlock) at a time
+                auto shape_Mask_gmem = make_shape(
+                    static_cast<int32_t>(params.total_q),                     // total_q rows (must match TMA descriptor)
+                    static_cast<int32_t>(params.sparse_mask_fine_q_stride)    // total cols = max_k_blocks * num_int32_per_block
+                );
+                Tensor mMask_TMA = params.tma_load_Mask.get_tma_tensor(shape_Mask_gmem);
+                // Apply offset for this Q block
+                Tensor gMask_TMA = local_tile(
+                    domain_offset(make_coord(seqlen_info.offset_q, _0{}), mMask_TMA),
+                    Shape<Int<kBlockM>, Int<kNumInt32PerBlock>>{},
+                    make_coord(_, _)  // (m_block, n_block * kNumInt32PerBlock offset)
+                );
+                auto block_tma_Mask = params.tma_load_Mask.get_slice(_0{});
+                Tensor tMaskgMask = group_modes<0, 3>(block_tma_Mask.partition_S(gMask_TMA));  // (TMA, m_block, k_offset)
+                Tensor tMasksMask = group_modes<0, 3>(block_tma_Mask.partition_D(sMask));  // (TMA, PIPE)
+                return cute::make_tuple(tMaskgMask, tMasksMask);
+            } else {
+                return cute::make_tuple(nullptr, nullptr);
+            }
+        }();
+        auto tMaskgMask_TMA = cute::get<0>(tMaskgMask_tMasksMask_tuple);
+        auto tMasksMask_TMA = cute::get<1>(tMaskgMask_tMasksMask_tuple);
+
+        auto load_Mask = [&] (int const m_block, int const n_block, auto const& smem_pipe_write) {
+            if constexpr (!Has_sparse_mask) {
+                return;
+            } else if constexpr (Use_TMA_Mask) {
+                // TMA path: single thread triggers TMA load
+                pipeline_mask.producer_acquire(smem_pipe_write);
+                copy(params.tma_load_Mask.with(*pipeline_mask.producer_get_barrier(smem_pipe_write), 0 /*mcast_mask*/, TMA::CacheHintSm90::EVICT_FIRST),
+                    tMaskgMask_TMA(_, m_block, n_block), tMasksMask_TMA(_, smem_pipe_write.index()));
+            } else {
+                // cp.async path
+                pipeline_mask.producer_acquire(smem_pipe_write);
+
+                int* stage_smem_base = shared_storage.tensors.mainloop.smem_mask.data() +
+                                        smem_pipe_write.index() * (kBlockM * kNumInt32PerBlock);
+
+                int const* src_base_common = params.sparse_mask_fine +
+                                                n_block * params.sparse_mask_fine_k_stride +
+                                                (seqlen_info.offset_q + m_block * kBlockM) * params.sparse_mask_fine_q_stride;
+
+                constexpr int total_elems = kBlockM * kNumInt32PerBlock;
+
+                int const block_row_start = m_block * kBlockM;
+
+                #pragma unroll
+                for (int i = thread_idx; i < total_elems; i += NumProducerThreads) {
+
+                    int const row_offset = i / kNumInt32PerBlock;
+                    int const word_idx   = i % kNumInt32PerBlock;
+
+                    int const row_logic = block_row_start + row_offset;
+                    bool const valid = (row_logic < seqlen_info.seqlen_q);
+
+                    int const* src = src_base_common +
+                                        row_offset * params.sparse_mask_fine_q_stride +
+                                        word_idx;
+
+                    flash::cp_async_ca_zfill(stage_smem_base + i, src, valid);
+                }
+
+                flash::cp_async_fence();
+                pipeline_mask.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
+            }
+        };
+
         auto load_K = [&] (int const n_block, auto const& smem_pipe_write, auto need_seqlenk_masking_type) {
             pipeline_k.producer_acquire(smem_pipe_write);
             if constexpr (!PagedKVNonTMA) {
@@ -818,6 +959,15 @@ struct CollectiveMainloopFwdSm90 {
             // if (thread_idx == 0) { printf("Producer: main load, after load K, index = %d\n", smem_pipe_write.index());}
         }
 
+        if constexpr (Has_sparse_mask) {
+            // TMA path: should_load_KV thread triggers the load; cp.async path: all threads participate
+            if constexpr (Use_TMA_Mask) {
+                if (should_load_KV) { load_Mask(m_block, n_block, smem_pipe_write); }
+            } else {
+                load_Mask(m_block, n_block, smem_pipe_write);
+            }
+        }
+
         if constexpr (Use_TMA_Q) {
             // Wait for the MMA warpgroups to signal that smem_q is ready
             if (SingleProducerWarp || warp_idx_in_warpgroup == 0) {
@@ -866,7 +1016,7 @@ struct CollectiveMainloopFwdSm90 {
         }
         int n_block_prev = n_block;
         --n_block;
-        #pragma unroll (!Transpose_V && Use_TMA_KV ? 2 : 1)
+        #pragma unroll (!Transpose_V && Use_TMA_KV && !Has_sparse_mask ? 2 : 1)
         for (; n_block >= n_block_min; --n_block) {
             PipelineState smem_pipe_write_v = smem_pipe_write; // copy the state, write_v is always 1 step behind
             ++smem_pipe_write;
@@ -886,6 +1036,14 @@ struct CollectiveMainloopFwdSm90 {
                     }
                 }
             }
+            if constexpr (Has_sparse_mask) {
+                // TMA path: should_load_KV thread triggers the load; cp.async path: all threads participate
+                if constexpr (Use_TMA_Mask) {
+                    if (should_load_KV) { load_Mask(m_block, n_block, smem_pipe_write); }
+                } else {
+                    load_Mask(m_block, n_block, smem_pipe_write);
+                }
+            }
             n_block_prev = n_block;
             if constexpr (Transpose_V) { copy_Vt_to_V(smem_pipe_write_v); }
         }
@@ -901,7 +1059,7 @@ struct CollectiveMainloopFwdSm90 {
 
     template <typename SharedStorage>
     CUTLASS_DEVICE void
-    load_tail(MainloopPipelineK pipeline_k, MainloopPipelineV pipeline_v, MainloopPipelineVt pipeline_vt,
+    load_tail(MainloopPipelineK pipeline_k, MainloopPipelineV pipeline_v, MainloopPipelineVt pipeline_vt, MainloopPipelineMask pipeline_mask,
               PipelineState& smem_pipe_write, SharedStorage &shared_storage, int const work_idx) {
         // If we don't wait for barrier_O here, when using Cluster, CTA0 might exit early and CTA1 will
         // try to arrive on barrier_O of CTA0, causing "unspecified launch failure".
@@ -916,6 +1074,7 @@ struct CollectiveMainloopFwdSm90 {
             */
             pipeline_k.producer_tail(smem_pipe_write);
             pipeline_v.producer_tail(smem_pipe_write);
+            if constexpr (Has_sparse_mask) {pipeline_mask.producer_tail(smem_pipe_write);}
             if constexpr (Transpose_V) { pipeline_vt.producer_tail(smem_pipe_write); }
         }
     }
@@ -964,6 +1123,7 @@ struct CollectiveMainloopFwdSm90 {
     mma(Params const& params,
         MainloopPipelineK pipeline_k,
         MainloopPipelineV pipeline_v,
+        MainloopPipelineMask pipeline_mask,
         PipelineState& smem_pipe_read,
         FrgTensorO& tOrO,
         Softmax& softmax,
@@ -1073,6 +1233,14 @@ struct CollectiveMainloopFwdSm90 {
             params.attention_chunk_divmod, params.qhead_per_khead_divmod
         );
 
+        // Sparse mask for Masked MHA (topk-based sparse attention)
+        // Note: When Has_sparse_mask is true, we don't need causal mask since NSA indexer already ensures causality
+        [[maybe_unused]] flash::SparseMask<kBlockM, kBlockN, PackGQA, TiledMmaQK> sparse_mask(
+            thread_idx, seqlen_q, seqlen_k,
+            params.sparse_mask_max_k_blocks,
+            params.qhead_per_khead_divmod
+        );
+
         float softcap_val = params.softcap_val;
         if constexpr (Has_softcap && Is_FP8) {
             float const q_descale = params.ptr_q_descale == nullptr ? 1.0f : params.ptr_q_descale[bidb * get<0>(params.stride_q_descale) + bidh_kv * get<1>(params.stride_q_descale)];
@@ -1156,7 +1324,18 @@ struct CollectiveMainloopFwdSm90 {
                 flash::gemm</*zero_init=*/false, /*wg_wait=*/0>(tiled_mma_qv, tSrQv, tSrV(_, _, _, smem_pipe_read.index()), tSrS);
             }
             scoremod_premask_fn(tSrS);
-            mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block);
+            // Apply mask: use sparse_mask when Has_sparse_mask, otherwise use regular causal/local mask
+            if constexpr (Has_sparse_mask) {
+                consumer_wait(pipeline_mask, smem_pipe_read);
+                uint32_t const* mask_ptr = reinterpret_cast<uint32_t const*>(
+                    shared_storage.tensors.mainloop.smem_mask.data() +
+                    smem_pipe_read.index() * (kBlockM * kNumInt32PerBlock)
+                );
+                sparse_mask.template apply<true /*Seqlenk_mask*/>(tSrS, m_block, n_block, mask_ptr);
+                pipeline_mask.consumer_release(smem_pipe_read);
+            } else {
+                mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block);
+            }
 
             Tensor scores_scale = softmax.template max_get_scale</*Is_first=*/true, /*Check_inf=*/true>(tSrS);
             // Don't need to store scales to send to WG1 (in the case of LargeHeadDimV) since it's 1.f
@@ -1199,7 +1378,13 @@ struct CollectiveMainloopFwdSm90 {
                     flash::gemm</*zero_init=*/false, /*wg_wait=*/0>(tiled_mma_qv, tSrQv, tSrV(_, _, _, smem_pipe_read.index()), tSrS);
                 }
                 scoremod_premask_fn(tSrS);
+                if constexpr (Has_sparse_mask) {
+                    consumer_wait(pipeline_mask, smem_pipe_read);
+                }
                 mask_fn(tSrS, n_block);
+                if constexpr (Has_sparse_mask) {
+                    pipeline_mask.consumer_release(smem_pipe_read); // release mask
+                }
                 cute::copy(softmax.template max_get_scale</*Is_first=*/false, Check_inf>(tSrS), scores_scale);
                 if constexpr (LargeHeadDimV) { store_scales(scores_scale, smem_pipe_read_v.index()); }
                 softmax.template online_softmax</*Is_first=*/false, Check_inf>(tSrS);
@@ -1215,31 +1400,47 @@ struct CollectiveMainloopFwdSm90 {
                 if constexpr (!MmaPV_is_RS) { arrive_on_P_write_barrier(); }
             };
 
-            if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
-                auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-                int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
-                    seqlen_info, m_block, n_block_min, params.window_size_right,
-                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
-                #pragma unroll 1
-                for (; n_block >= n_block_min_causal_local_mask; --n_block) {
-                    fwd_step(n_block, mask_fn, cute::true_type{} /*check_inf*/);
-                }
-            }
-
-            int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
-                seqlen_info, m_block, n_block_min, params.window_size_left,
-                params.attention_chunk_divmod, params.qhead_per_khead_divmod);
-            auto no_mask_fn = [](auto& tSrS, int n_block) { };
-            #pragma unroll 1
-            for (; n_block >= n_block_min_before_local_mask; --n_block) {
-                fwd_step(n_block, no_mask_fn, cute::false_type{} /*check_inf*/);
-            }
-            // Separate masking iterations on the left for local attention
-            if constexpr (Is_local) {
-                auto local_mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, false /*Causal_mask*/, Is_local>(tSrS, m_block, n_block); };
+            // When Has_sparse_mask is true, apply sparse_mask for all iterations
+            // (Is_causal and Is_local are both false in this case, so we need a separate branch)
+            if constexpr (Has_sparse_mask) {
+                auto sparse_mask_fn = [&](auto& tSrS, int n_block) {
+                    uint32_t const* mask_ptr = reinterpret_cast<uint32_t const*>(
+                        shared_storage.tensors.mainloop.smem_mask.data() +
+                        smem_pipe_read.index() * (kBlockM * kNumInt32PerBlock)
+                    );
+                    sparse_mask.template apply<false /*Seqlenk_mask*/>(tSrS, m_block, n_block, mask_ptr);
+                };
                 #pragma unroll 1
                 for (; n_block >= n_block_min; --n_block) {
-                    fwd_step(n_block, local_mask_fn, cute::bool_constant<Is_local>{} /*check_inf*/);
+                    fwd_step(n_block, sparse_mask_fn, cute::true_type{} /*check_inf*/);
+                }
+            } else {
+                if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
+                    auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
+                    int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
+                        seqlen_info, m_block, n_block_min, params.window_size_right,
+                        params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                    #pragma unroll 1
+                    for (; n_block >= n_block_min_causal_local_mask; --n_block) {
+                        fwd_step(n_block, mask_fn, cute::true_type{} /*check_inf*/);
+                    }
+                }
+
+                int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
+                    seqlen_info, m_block, n_block_min, params.window_size_left,
+                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                auto no_mask_fn = [](auto& tSrS, int n_block) { };
+                #pragma unroll 1
+                for (; n_block >= n_block_min_before_local_mask; --n_block) {
+                    fwd_step(n_block, no_mask_fn, cute::false_type{} /*check_inf*/);
+                }
+                // Separate masking iterations on the left for local attention
+                if constexpr (Is_local) {
+                    auto local_mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, false /*Causal_mask*/, Is_local>(tSrS, m_block, n_block); };
+                    #pragma unroll 1
+                    for (; n_block >= n_block_min; --n_block) {
+                        fwd_step(n_block, local_mask_fn, cute::bool_constant<Is_local>{} /*check_inf*/);
+                    }
                 }
             }
             // Tell producers that smem_q is ready
@@ -1261,7 +1462,6 @@ struct CollectiveMainloopFwdSm90 {
             ++smem_pipe_read;
 
         } else {  // No intra-WG overlap
-
             warp_scheduler_barrier_sync();
 
             auto fwd_step = [&](int const n_block, auto mask_fn, auto is_first_iter_type, auto check_inf_type) {
@@ -1288,7 +1488,13 @@ struct CollectiveMainloopFwdSm90 {
                     warpgroup_wait<0>();
                 }
                 scoremod_premask_fn(tSrS);
+                if constexpr (Has_sparse_mask) {
+                    consumer_wait(pipeline_mask, smem_pipe_read);
+                }
                 mask_fn(tSrS, n_block);
+                if constexpr (Has_sparse_mask) {
+                    pipeline_mask.consumer_release(smem_pipe_read); // release mask
+                }
                 Tensor scores_scale = softmax.template max_get_scale</*Is_first=*/Is_first_iter, Check_inf>(tSrS);
                 if constexpr (LargeHeadDimV && !Is_first_iter) { store_scales(scores_scale, smem_pipe_read_prev.index()); }
                 softmax.template online_softmax</*Is_first=*/Is_first_iter, Check_inf>(tSrS);
@@ -1313,11 +1519,32 @@ struct CollectiveMainloopFwdSm90 {
                 pipeline_v.consumer_release(smem_pipe_read);  // release V
             };
 
-            auto first_iter_mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
+            // First iteration mask function: use sparse_mask when Has_sparse_mask
+            auto first_iter_mask_fn = [&](auto& tSrS, int n_block) {
+                if constexpr (Has_sparse_mask) {
+                    uint32_t const* mask_ptr = reinterpret_cast<uint32_t const*>(
+                        shared_storage.tensors.mainloop.smem_mask.data() +
+                        smem_pipe_read.index() * (kBlockM * kNumInt32PerBlock)
+                    );
+                    sparse_mask.template apply<true /*Seqlenk_mask*/>(tSrS, m_block, n_block, mask_ptr);
+                } else {
+                    mask.template apply<true /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block);
+                }
+            };
             fwd_step(n_block, first_iter_mask_fn, cute::true_type{} /*is_first_iter*/, cute::true_type{} /*check_inf*/);
             --n_block;
             if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
-                auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
+                auto mask_fn = [&](auto& tSrS, int n_block) {
+                    if constexpr (Has_sparse_mask) {
+                        uint32_t const* mask_ptr = reinterpret_cast<uint32_t const*>(
+                            shared_storage.tensors.mainloop.smem_mask.data() +
+                            smem_pipe_read.index() * (kBlockM * kNumInt32PerBlock)
+                        );
+                        sparse_mask.template apply<false /*Seqlenk_mask*/>(tSrS, m_block, n_block, mask_ptr);
+                    } else {
+                        mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block);
+                    }
+                };
                 int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
                     seqlen_info, m_block, n_block_min, params.window_size_right,
                     params.attention_chunk_divmod, params.qhead_per_khead_divmod);

--- a/hopper/mask.h
+++ b/hopper/mask.h
@@ -163,4 +163,160 @@ struct Mask {
 
 };
 
+template <int kBlockM, int kBlockN, bool PackGQA, typename TiledMma, bool SwapAB=false>
+struct SparseMask {
+    static constexpr int kNumInt32PerBlock = (kBlockN + 31) / 32;
+
+    int const thread_idx;
+    int const seqlen_q, seqlen_k;
+    int const max_k_blocks;
+    cutlass::FastDivmod const qhead_per_khead_divmod;
+
+    CUTLASS_DEVICE
+    SparseMask(const int thread_idx, const int seqlen_q, const int seqlen_k,
+               int const max_k_blocks,
+               cutlass::FastDivmod const qhead_per_khead_divmod
+            )
+        : thread_idx(thread_idx)
+        , seqlen_q(seqlen_q)
+        , seqlen_k(seqlen_k)
+        , max_k_blocks(max_k_blocks)
+        , qhead_per_khead_divmod(qhead_per_khead_divmod)
+    {
+    }
+
+    // smem_mask_ptr -> current smem in stage
+    // Reordered layout: bits are grouped by quad_lane for optimal GMMA access
+    //   For kBlockN=128 (4 words, 32 bits per quad_lane):
+    //     - word0: quad_lane 0, word1: quad_lane 1, word2: quad_lane 2, word3: quad_lane 3
+    //   For kBlockN=64 (2 words, 16 bits per quad_lane):
+    //     - word0 low 16: quad_lane 0, word0 high 16: quad_lane 1
+    //     - word1 low 16: quad_lane 2, word1 high 16: quad_lane 3
+    template <bool Seqlenk_mask=false, typename Engine, typename Layout>
+    CUTLASS_DEVICE
+    void apply(Tensor<Engine, Layout> &tSrS, const int m_block, const int n_block,
+               uint32_t const* __restrict__ smem_mask_ptr) const {
+
+        auto thread_mma = TiledMma{}.get_thread_slice(thread_idx);
+        auto thread0_mma = TiledMma{}.get_thread_slice(_0{});
+        static constexpr int Row = !SwapAB ? 0 : 1, Col = !SwapAB ? 1 : 0;
+
+        Tensor cS = cute::make_identity_tensor(Shape<Int<!SwapAB ? kBlockM : kBlockN>, Int<!SwapAB ? kBlockN : kBlockM>>{});
+        Tensor tScS = thread_mma.partition_C(cS);
+        Tensor t0ScS = thread0_mma.partition_C(cS);
+        Tensor tSrS_rowcol = make_tensor(tSrS.data(), flash::convert_layout_acc_rowcol</*Transposed=*/SwapAB>(tSrS.layout()));
+        Tensor tScS_rowcol = make_tensor(tScS.data(), flash::convert_layout_acc_rowcol</*Transposed=*/SwapAB>(tScS.layout()));
+        Tensor t0ScS_rowcol = make_tensor(t0ScS.data(), flash::convert_layout_acc_rowcol</*Transposed=*/SwapAB>(t0ScS.layout()));
+
+        static constexpr int kMmaThreadsPerRow = size<0, 0>(typename TiledMma::AtomLayoutC_TV{});
+
+        // Compute quad_lane from thread_col_offset (compile-time derivable per thread)
+        // quad_lane 0,1,2,3 have thread_col_offset 0,2,4,6 respectively
+        int const thread_col_offset = get<Col>(tScS_rowcol(_0{}, _0{}));
+        int const quad_lane = thread_col_offset / 2;
+
+        // For seqlenk_mask: use thread0's column indices (compile-time known) with adjusted limit
+        int const seqlenk_col_limit = seqlen_k - n_block * kBlockN - thread_col_offset;
+
+        const bool is_block_safe = n_block < max_k_blocks;
+
+        #pragma unroll
+        for (int m = 0; m < size<0>(tSrS_rowcol); ++m) {
+            int local_row = get<Row>(tScS_rowcol(m, _0{}));
+
+            int global_row_idx;
+            if constexpr (!PackGQA) {
+                global_row_idx = local_row + m_block * kBlockM;
+            } else {
+                int mma_m_idx = qhead_per_khead_divmod.divide(m_block * kBlockM + local_row);
+                global_row_idx = __shfl_sync(0xffffffff, mma_m_idx, m % kMmaThreadsPerRow, kMmaThreadsPerRow);
+            }
+
+            bool const is_row_safe = (global_row_idx < seqlen_q) && is_block_safe;
+            if (!is_row_safe) {
+                #pragma unroll
+                for (int n = 0; n < size<1>(tSrS_rowcol); ++n) {
+                    tSrS_rowcol(m, n) = -INFINITY;
+                }
+                continue;
+            }
+
+            if constexpr (kBlockN == 128) {
+                // Reordered layout: each quad_lane's 32 bits are in one word
+                // Read only the word needed by this thread's quad_lane
+                uint32_t const mask_word = smem_mask_ptr[local_row * 4 + quad_lane];
+
+                #pragma unroll
+                for (int n = 0; n < size<1>(tSrS_rowcol); ++n) {
+                    // In reordered layout, bit index = n (compile-time known!)
+                    bool const mask_bit = (mask_word >> n) & 1;
+
+                    if constexpr (Seqlenk_mask) {
+                        // Use thread0's column index (compile-time known) with adjusted limit
+                        int const col0 = int(get<Col>(t0ScS_rowcol(_0{}, n)));
+                        bool const is_valid = col0 < seqlenk_col_limit;
+                        bool const final_keep = is_valid && mask_bit;
+                        if (!final_keep) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    } else {
+                        if (!mask_bit) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    }
+                }
+            } else if constexpr (kBlockN == 64) {
+                // Reordered layout: quad_lane 0,1 share word0, quad_lane 2,3 share word1
+                // Each quad_lane gets 16 bits (low or high half)
+                int const word_idx = quad_lane / 2;
+                int const half_idx = quad_lane % 2;
+                uint32_t const full_word = smem_mask_ptr[local_row * 2 + word_idx];
+                uint32_t const mask_word = half_idx ? (full_word >> 16) : full_word;
+
+                #pragma unroll
+                for (int n = 0; n < size<1>(tSrS_rowcol); ++n) {
+                    // In reordered layout, bit index = n (compile-time known!)
+                    bool const mask_bit = (mask_word >> n) & 1;
+
+                    if constexpr (Seqlenk_mask) {
+                        int const col0 = int(get<Col>(t0ScS_rowcol(_0{}, n)));
+                        bool const is_valid = col0 < seqlenk_col_limit;
+                        bool const final_keep = is_valid && mask_bit;
+                        if (!final_keep) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    } else {
+                        if (!mask_bit) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    }
+                }
+            } else {
+                // General case for other kBlockN values (fallback to original logic)
+                // This assumes the mask is NOT reordered for non-standard sizes
+                #pragma unroll
+                for (int n = 0; n < size<1>(tSrS_rowcol); ++n) {
+                    int const token_in_block = int(get<Col>(tScS_rowcol(m, n)));
+                    int const word_idx = token_in_block / 32;
+                    int const bit_idx = token_in_block % 32;
+
+                    bool const mask_bit = (smem_mask_ptr[local_row * kNumInt32PerBlock + word_idx] >> bit_idx) & 1;
+
+                    if constexpr (Seqlenk_mask) {
+                        bool const is_valid = (n_block * kBlockN + token_in_block < seqlen_k);
+                        bool const final_keep = is_valid && mask_bit;
+                        if (!final_keep) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    } else {
+                        if (!mask_bit) {
+                            tSrS_rowcol(m, n) = -INFINITY;
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
 } // namespace flash

--- a/hopper/static_switch.h
+++ b/hopper/static_switch.h
@@ -202,3 +202,15 @@
       return __VA_ARGS__();                                                                      \
     }                                                                                            \
   }()
+
+// Sparse mask switch for Masked MHA (topk-based sparse attention)
+// Only supported on SM90+ with the TMA GMMA mainloop
+#ifdef FLASHATTENTION_DISABLE_SPARSE_MASK
+  #define SPARSE_MASK_SWITCH(COND, CONST_NAME, ...)                                              \
+  [&] {                                                                                          \
+    constexpr static bool CONST_NAME = false;                                                    \
+    return __VA_ARGS__();                                                                        \
+  }()
+#else
+  #define SPARSE_MASK_SWITCH BOOL_SWITCH
+#endif

--- a/hopper/utils.h
+++ b/hopper/utils.h
@@ -239,6 +239,15 @@ void cp_async_wait() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template <typename TS, typename TD>
+CUTE_HOST_DEVICE
+void cp_async_ca_zfill(TD* smem_ptr, TS const* gmem_ptr, bool pred) {
+    SM80_CP_ASYNC_CACHEALWAYS_ZFILL<TS, TD>::copy(*gmem_ptr, *smem_ptr, pred);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
 template <bool A, class Mma, class Tensor0>
 CUTLASS_DEVICE
 auto mma_partition_fragment_AB(Mma const& mma, Tensor0 const& tensor0) {


### PR DESCRIPTION
# Add Sparse Mask Support for Masked Multi-Head Attention

## Summary
This PR adds support for fine-grained sparse masks in FlashAttention, enabling efficient topK-based sparse attention patterns on Hopper (sm90a) architecture.

Mask generation kernel: https://github.com/leavelet/sparse_mask_lib

## Key Features

### 1. **Sparse Mask Infrastructure**
- Added `sparse_mask_fine` parameter: 3D tensor `[total_q, max_k_blocks, num_int32_per_block]` containing block-level bitmaps
- Supports fine-grained masking at the token level with efficient block-based storage
- Requires 128-byte TMA alignment for optimal performance

### 2. **New API Components**

**C++/CUDA:**
- Added sparse mask parameters to `Flash_fwd_params` structure
- Implemented TMA-based mask loading pipeline (`MainloopPipelineMask`)
- Added `SparseMask` class in `mask.h` with optimized GMMA-friendly bit layout
- Added build-time flag `FLASHATTENTION_DISABLE_SPARSE_MASK` for optional compilation

**Python:**
- Added `sparse_mask_fine` parameter to all forward functions:
  - `flash_attn_func()`
  - `flash_attn_varlen_func()`
  - `flash_attn_with_kvcache()`
- Added `get_tile_size()` utility function to query `(kBlockM, kBlockN)` for mask generation

### 3. **Implementation Details**

**Mask Layout Optimization:**
- Reordered bitmap layout for optimal GMMA access patterns
- For `kBlockN=128`: 4 words, 32 bits per quad-lane
- For `kBlockN=64`: 2 words, 16 bits per quad-lane
- Achieves zero memory bank conflicts during mask application

**Pipeline Integration:**
- Dual-path support: TMA (primary) and cp.async (fallback)
- Mask loading overlapped with K/V loading in producer warp
- Consumer threads apply masks during score computation with minimal overhead

### 4. **Constraints & Requirements**
- Hopper architecture (SM90+) only
- Row stride must be multiple of 128 bytes for TMA alignment
- When sparse mask is enabled, causal masking is disabled

## Usage Example

```python
import torch
from flash_attn_interface import flash_attn_varlen_func, get_tile_size
from sparse_mask import prepare_sparse_mask

# Query tile size for mask generation
kBlockM, kBlockN = get_tile_size(
            headdim=layer.head_dim,
            headdim_v=layer.v_head_dim,
            qkv_dtype=q.dtype,
            is_causal=False,  # causality handled by topk_indices
        )

# Generate sparse mask (e.g., from topK selection)
num_int32_per_block = (kBlockN + 31) // 32
max_k_blocks = (max_seqlen_k + kBlockN - 1) // kBlockN
sparse_mask = torch.zeros(total_q, max_k_blocks, num_int32_per_block, 
                          dtype=torch.int32, device='cuda')
# Generate sparse masks from topk_indices
total_q = q.shape[0]
max_seqlen_k = metadata.max_seq_len_k
# Pad max_seqlen_k to be multiple of 16 for TMA load

max_k_blocks = (max_seqlen_k + kBlockN - 1) // kBlockN
num_int32_per_block = (kBlockN + 31) // 32
product = max_k_blocks * num_int32_per_block
if product % 32 != 0:
    aligned_product = ((product + 31) // 32) * 32
    max_k_blocks = aligned_product // num_int32_per_block

fine_mask = prepare_sparse_mask(
            topk_indices=topk_indices,
            total_q=total_q,
            max_seqlen_k=max_seqlen_k,
            max_k_blocks=max_k_blocks,
            kBlockN=kBlockN,
            kBlockM=kBlockM,
            reordered=True,
        )

# Run attention with sparse mask
out = flash_attn_varlen_func(
    q, k, v,
    cu_seqlens_q, cu_seqlens_k,
    max_seqlen_q, max_seqlen_k,
    sparse_mask_fine=sparse_mask
)
```

## Testing
- Validated on H100 with various sequence lengths and head dimensions