### PR TITLE
[WIP] feat: Add n_offset optimization for sliding window attention

### DIFF
--- a/hopper/block.h
+++ b/hopper/block.h
@@ -11,28 +11,18 @@ struct BlockMN {
 
     static
     CUTLASS_DEVICE
-    cute::tuple<int, int> get_n_block_min_max(
+    cute::tuple<int, int, int> get_n_block_min_max(
             SeqlenInfo_t const& seqlen_info,
             int const m_block, int const bidb, int const split_idx, int const num_splits,
             int const window_size_left, int const window_size_right,
             cutlass::FastDivmod const& attention_chunk_divmod,
             cutlass::FastDivmod const& qhead_per_khead_divmod) {
 
-        int const seqlen_k = seqlen_info.seqlen_k;
+        int seqlen_k = seqlen_info.seqlen_k;
         int const seqlen_q = seqlen_info.seqlen_q;
-        int n_block_max = cute::ceil_div(seqlen_k, kBlockN);
-        if constexpr (Is_causal || Is_local) {
-            int m_idx_max = (m_block + 1) * kBlockM;
-            // TODO: check off-by-1 error
-            if (PackGQA) { m_idx_max = qhead_per_khead_divmod.divide(m_idx_max - 1) + 1 ; }
-            int const n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q;
-            int n_idx_right = !Is_local ? n_idx : n_idx + window_size_right;
-            if (Is_local && attention_chunk_divmod.divisor > 0) {
-                n_idx_right = std::min(n_idx_right, flash::round_up(attention_chunk_divmod, n_idx));
-            }
-            n_block_max = std::min(n_block_max, cute::ceil_div(n_idx_right, kBlockN));
-        }
-        int n_block_min = 0;
+        int n_offset = 0;
+
+        // If local, calculate n_offset and update seqlen_k
         if constexpr (Is_local) {
             int m_idx_min = m_block * kBlockM;
             if (PackGQA) { m_idx_min = qhead_per_khead_divmod.divide(m_idx_min); }
@@ -41,8 +31,23 @@ struct BlockMN {
             if (attention_chunk_divmod.divisor > 0) {
                 n_idx_left = std::max(n_idx_left, flash::round_down(attention_chunk_divmod, n_idx));
             }
-            n_block_min = std::max(int(0), n_idx_left / kBlockN);
+            // unlike previously, we don't divide by kBlockN because we want offset for seqlen_k
+            n_offset = std::max(int(0), n_idx_left);
+            // Subtract n_offset from seqlen_k for subsequent calculations such as n_block_max
+            seqlen_k -= n_offset;
         }
+
+        int n_block_max = cute::ceil_div(seqlen_k, kBlockN);
+        if constexpr (Is_causal || Is_local) {
+            int m_idx_max = (m_block + 1) * kBlockM;
+            // TODO: check off-by-1 error
+            if (PackGQA) { m_idx_max = qhead_per_khead_divmod.divide(m_idx_max - 1) + 1 ; }
+            // If local, blocking (m_idx_max - m_idx_min + window_size_right + window_size_left)
+            n_block_max = std::min(n_block_max,
+                                   cute::ceil_div(m_idx_max + seqlen_k - seqlen_q + window_size_right, kBlockN));
+        }
+        // Now, only adjust n_block_min if split
+        int n_block_min = 0;
         // if (threadIdx.x == 128) { printf("Inside, bid.x = %d, bid.y = %d, bid.z = %d, split_idx = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.x, blockIdx.y, blockIdx.z, split_idx, n_block_min, n_block_max); }
         if constexpr (Split) {
             uint32_t num_splits_dynamic_u = reinterpret_cast<uint32_t const&>(split_idx) >> 16; // first 16 bits are for num_splits
@@ -55,7 +60,8 @@ struct BlockMN {
             // if (threadIdx.x == 128) { printf("Inside, bid.x = %d, bid.y = %d, bid.z = %d, split_idx = %d, num_splits_dynamic = %d, num_splits_actual = %d, num_n_blocks_per_split = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.x, blockIdx.y, blockIdx.z, split_idx, num_splits_dynamic, num_splits_actual, num_n_blocks_per_split, n_block_min, n_block_max); }
         }
         // if (threadIdx.x == 128) { printf("After split, inside, bid.y = %d, bid.z = %d, split_idx = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.y, blockIdx.z, split_idx, n_block_min, n_block_max); }
-        return {n_block_min, n_block_max};
+        // Return n_offset to add to KV gmem pointers and use in masks
+        return {n_block_min, n_block_max, n_offset};
     }
 
     static
@@ -67,11 +73,12 @@ struct BlockMN {
             cutlass::FastDivmod const& attention_chunk_divmod,
             cutlass::FastDivmod const& qhead_per_khead_divmod) {
 
-        auto [n_block_min, n_block_max] = get_n_block_min_max(
+        // TODO: check logic with n_offset
+        auto [n_block_min, n_block_max, n_offset] = get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, num_splits,
             window_size_left, window_size_right, attention_chunk_divmod, qhead_per_khead_divmod);
-        int const idx_k_new_min = std::max(n_block_min * kBlockN - seqlen_info.seqlen_k_og, 0);
-        int const idx_k_new_max = std::min(n_block_max * kBlockN - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new);
+        int const idx_k_new_min = std::max(n_block_min * kBlockN + n_offset - seqlen_info.seqlen_k_og, 0);
+        int const idx_k_new_max = std::min(n_block_max * kBlockN + n_offset - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new);
         int const n_block_new_min = idx_k_new_min / kBlockN;
         int const n_block_new_max = idx_k_new_max > idx_k_new_min ? cute::ceil_div(idx_k_new_max, kBlockN) : n_block_new_min;
         // if (threadIdx.x == 128 && m_block == 0) { printf("bidb = %d, seqlen_k_new = %d, seqlen_k_og = %d, n_block_min = %d, n_block_max = %d, idx_k_new_min = %d, idx_k_new_max = %d, n_block_new_min = %d, n_block_new_max = %d\n", bidb, seqlen_k_new, seqlen_k_og, n_block_min, n_block_max, idx_k_new_min, idx_k_new_max, n_block_new_min, n_block_new_max);}

--- a/hopper/epilogue_fwd.hpp
+++ b/hopper/epilogue_fwd.hpp
@@ -21,7 +21,7 @@ namespace flash {
 using namespace cute;
 
 template <class TileShape_MNK_PV_, class ClusterShape_, class Element_, class ArchTag_,
-          int NumEpilogueThreads_, bool Varlen_, bool PackGQA_, bool Split_, bool FP8PermuteCol=false>
+          int NumEpilogueThreads_, bool Varlen_, bool PackGQA_, bool Split_, bool FP8PermuteCol=false, int kBlockH_=1>
 struct CollectiveEpilogueFwd {
 
     using TileShape_MNK_PV = TileShape_MNK_PV_;
@@ -32,9 +32,10 @@ struct CollectiveEpilogueFwd {
     static constexpr int NumEpilogueThreads = NumEpilogueThreads_;
     static constexpr bool Varlen = Varlen_;
     static constexpr bool PackGQA = PackGQA_;
+    static constexpr bool PackGQA_TMA = PackGQA && (kBlockH_ > 1);
     static constexpr bool Split = Split_;
     static constexpr bool Use_smem = !(Split && !Varlen);
-    static constexpr bool Use_TMA_O = ArchTag::kMinComputeCapability >= 90 && !Varlen && !Split && !PackGQA;
+    static constexpr bool Use_TMA_O = ArchTag::kMinComputeCapability >= 90 && !Varlen && !Split && (!PackGQA || PackGQA_TMA);
 
     static_assert(ArchTag::kMinComputeCapability >= 80);
     static_assert(ArchTag::kMinComputeCapability >= 90 || CUTE_STATIC_V(size(ClusterShape{})) == 1);
@@ -42,6 +43,7 @@ struct CollectiveEpilogueFwd {
 
     static constexpr int kBlockM = get<0>(TileShape_MNK_PV{});
     static constexpr int kHeadDimV = get<1>(TileShape_MNK_PV{});
+    static constexpr int kBlockH = kBlockH_;
 
     static constexpr bool LargeHeadDimV = kHeadDimV > 256;
 
@@ -83,7 +85,10 @@ struct CollectiveEpilogueFwd {
     using StrideO = cute::Stride<int64_t, _1, int64_t, int64_t, int64_t>;
     using StrideLSE = cute::Stride<_1, int64_t, int64_t, int64_t>;            // (seqlen_q, head, batch, num_splits)
     // ((qhead_per_khead, seqlen_q), d, nheads_kv, batch, num_splits)
-    using ShapeOPacked = std::conditional_t<!PackGQA, ShapeO, cute::Shape<cute::Shape<int32_t, int32_t>, int32_t, int32_t, int32_t, int32_t>>;
+    using ShapeOPackedTMA = std::conditional_t<!PackGQA, ShapeO, cute::Shape<cute::Shape<Int<kBlockH>, int32_t>, int32_t, int32_t, int32_t, int32_t>>;
+    using ShapeOPacked = std::conditional_t<PackGQA && !PackGQA_TMA,
+        cute::Shape<cute::Shape<int32_t, int32_t>, int32_t, int32_t, int32_t, int32_t>,
+        ShapeOPackedTMA>;
     using StrideOPacked = std::conditional_t<!PackGQA, StrideO, cute::Stride<cute::Stride<int64_t, int64_t>, _1, int64_t, int64_t, int64_t>>;
     // ((qhead_per_khead, seqlen_q), nheads_kv, batch, num_splits)
     using ShapeLSEPacked = std::conditional_t<!PackGQA, cute::Shape<int32_t, int32_t, int32_t, int32_t>, cute::Shape<cute::Shape<int32_t, int32_t>, int32_t, int32_t, int32_t>>;
@@ -111,7 +116,7 @@ struct CollectiveEpilogueFwd {
         Use_TMA_O,
         decltype(make_tma_copy(
             GmemTiledCopyOTMA{},
-            make_tensor(make_gmem_ptr(static_cast<Element*>(nullptr)), ShapeO{}, StrideO{}),
+            make_tensor(make_gmem_ptr(static_cast<Element*>(nullptr)), ShapeOPackedTMA{}, StrideOPacked{}),
             SmemLayoutOTMA{},
             select<0, 1>(TileShape_MNK_PV{}),
             _1{})),  // no mcast for O
@@ -159,7 +164,19 @@ struct CollectiveEpilogueFwd {
 
     static Params
     to_underlying_arguments(Arguments const& args) {
-        Tensor mO = make_tensor(make_gmem_ptr(args.ptr_O), args.shape_O, args.stride_O);
+        // If PackGQA, reshape O to be ((qhead_per_khead, seqlen_q), head_size, nhead_k, batch_size, num_splits)
+        int const qhead_per_khead = !PackGQA ? 1 : cute::ceil_div(get<2>(args.shape_O), args.nheads_kv);
+        auto const shape_O_packed = cute::conditional_return<!PackGQA>(
+            args.shape_O,
+            make_shape(
+                make_shape(cute::conditional_return<PackGQA_TMA>(Int<kBlockH>{}, qhead_per_khead), get<0>(args.shape_O)),
+                get<1>(args.shape_O), args.nheads_kv, get<3>(args.shape_O), get<4>(args.shape_O))
+        );
+        auto const stride_O_packed = cute::conditional_return<!PackGQA>(
+            args.stride_O,
+            make_stride(make_stride(get<2>(args.stride_O), get<0>(args.stride_O)), get<1>(args.stride_O), get<2>(args.stride_O) * qhead_per_khead, get<3>(args.stride_O), get<4>(args.stride_O))
+        );
+        Tensor mO = make_tensor(make_gmem_ptr(args.ptr_O), shape_O_packed, stride_O_packed);
         TMA_O tma_store_O = [&]{
             if constexpr (Use_TMA_O) {
                 return make_tma_copy(GmemTiledCopyOTMA{}, mO, SmemLayoutO{}, select<0, 1>(TileShape_MNK_PV{}), _1{}); // no mcast
@@ -167,16 +184,6 @@ struct CollectiveEpilogueFwd {
                 return nullptr;
             }
         }();
-        // If PackGQA, reshape O to be ((qhead_per_khead, seqlen_q), head_size, nhead_k, batch_size, num_splits)
-        int const qhead_per_khead = !PackGQA ? 1 : cute::ceil_div(get<2>(args.shape_O), args.nheads_kv);
-        auto const shape_O_packed = cute::conditional_return<!PackGQA>(
-            args.shape_O,
-            make_shape(make_shape(qhead_per_khead, get<0>(args.shape_O)), get<1>(args.shape_O), args.nheads_kv, get<3>(args.shape_O), get<4>(args.shape_O))
-        );
-        auto const stride_O_packed = cute::conditional_return<!PackGQA>(
-            args.stride_O,
-            make_stride(make_stride(get<2>(args.stride_O), get<0>(args.stride_O)), get<1>(args.stride_O), get<2>(args.stride_O) * qhead_per_khead, get<3>(args.stride_O), get<4>(args.stride_O))
-        );
         auto const stride_O_partial_packed = cute::conditional_return<!PackGQA>(
             args.stride_O_partial,
             make_stride(make_stride(get<2>(args.stride_O_partial), get<0>(args.stride_O_partial)), get<1>(args.stride_O_partial), get<2>(args.stride_O_partial) * qhead_per_khead, get<3>(args.stride_O_partial), get<4>(args.stride_O_partial))
@@ -309,7 +316,7 @@ struct CollectiveEpilogueFwd {
 
         // Step 3: Write O from smem -> gmem
         if constexpr (Use_TMA_O) {
-            Tensor mO = params.tma_store_O.get_tma_tensor(params.shape_O)(_, _, bidh, bidb, split_idx);
+            Tensor mO = params.tma_store_O.get_tma_tensor(params.shape_O_packed)(_, _, bidh, bidb, split_idx);
             Tensor gO = local_tile(mO, select<0, 1>(TileShape_MNK_PV{}), make_coord(m_block, _0{}));  // (M, K)
             auto block_tma_O = params.tma_store_O.get_slice(_0{});
             Tensor tOgO = block_tma_O.partition_D(gO);  // (TMA, TMA_M, TMA_K)

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -393,7 +393,8 @@ void run_mha_fwd_combine(Flash_fwd_params &params, cudaStream_t stream, bool ena
 }
 
 inline bool get_pagedkv_tma(Flash_fwd_params const& params) {
-    if (params.arch < 90 || !params.page_table || params.leftpad_k || params.knew_ptr) { return false; }
+    // disable for local since we move k_ptr to start of sliding window by m_block
+    if (params.arch < 90 || !params.page_table || params.leftpad_k || params.knew_ptr || params.is_local) { return false; }
     // This needs to match the kernel configs
     auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, false /*paged_kv_non_TMA*/, params.softcap > 0.f, use_one_mma_wg(params));
     int const kBlockM = std::get<0>(kBlockMN_kernel_args_sm90);
@@ -407,6 +408,11 @@ inline bool get_pack_gqa(Flash_fwd_params const& params) {
     // Always enable PackGQA for Sm8x or PagedKVNonTMA or Split to reduce compilation and binary size.
     // Has little effect on speed.
     if (params.arch < 90 || (params.page_table && !params.pagedkv_tma) || params.num_splits > 1) { return true; }
+    // Always enable PackGQA for special case of hdim = 64, qheads/kvheads = 8, local attention
+    bool const packgqa_override = params.arch >= 90 && (params.h / params.h_k) == 8 && 
+                                  params.is_local && 
+                                  params.d == 64 && (params.dv == params.d);
+    if (packgqa_override) { return true; }
     #ifdef FLASHATTENTION_DISABLE_PACKGQA
     return false;
     #else

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -27,7 +27,7 @@ using namespace cute;
 
 template <int Arch, int kHeadDim, int kHeadDimV, int ClusterM, typename Element, typename ElementOut,
           bool Is_causal, bool Is_local, bool Has_softcap, bool Varlen, bool PagedKVNonTMA, bool AppendKV, bool HasQv,
-          bool PackGQA, bool Split, bool V_colmajor, bool Use_one_mma_wg>
+          bool PackGQA, bool Split, bool V_colmajor, bool Use_one_mma_wg, int kBlockH=1>
 void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     static_assert(!(Is_causal && Is_local), "Causal and Local cannot be enabled at the same time");
     static_assert(!(AppendKV && V_colmajor), "AppendKV and V_colmajor cannot be enabled at the same time");
@@ -53,10 +53,10 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     using ClusterShape = cute::Shape<Int<ClusterM>, _1, _1>;
     using CollectiveMainloop = std::conditional_t<
         Arch >= 90,
-        flash::CollectiveMainloopFwdSm90<kStages, ClusterShape, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm90, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, HasQv, MmaPV_is_RS, IntraWGOverlap, PackGQA, Split, V_colmajor, ElementSink>,
+        flash::CollectiveMainloopFwdSm90<kStages, ClusterShape, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm90, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, HasQv, MmaPV_is_RS, IntraWGOverlap, PackGQA, Split, V_colmajor, ElementSink, kBlockH>,
         flash::CollectiveMainloopFwdSm80<kNWarps, kStages, Q_in_regs, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm80, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, PackGQA, Split, ElementSink>
     >;
-    using CollectiveEpilogue = flash::CollectiveEpilogueFwd<TileShape_MNK_PV, ClusterShape, ElementOut, ArchTag, CollectiveMainloop::NumMmaThreads, Varlen, PackGQA, Split, FP8_TransposeV>;
+    using CollectiveEpilogue = flash::CollectiveEpilogueFwd<TileShape_MNK_PV, ClusterShape, ElementOut, ArchTag, CollectiveMainloop::NumMmaThreads, Varlen, PackGQA, Split, FP8_TransposeV, kBlockH>;
 
     static constexpr int NumProducerThreads = Arch >= 90 ? CollectiveMainloop::NumProducerThreads : CollectiveMainloop::NumMmaThreads;
     static constexpr bool LPT = Is_causal || Is_local;
@@ -212,7 +212,7 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
             VARLEN_SWITCH(params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k, Varlen, [&] {
                 BOOL_SWITCH(use_one_mma_wg(params), Use_one_mma_wg_, [&] {
                     // Only enable for headdim 64/128 on Hopper with same Q/K and V headdim, non-local
-                    static constexpr bool Use_one_mma_wg = Use_one_mma_wg_ && Arch >= 90 && (kHeadDim == 128 || kHeadDim == 64) && (kHeadDimV == kHeadDim) && !Is_local;
+                    static constexpr bool Use_one_mma_wg = Use_one_mma_wg_ && Arch >= 90 && (kHeadDim == 128 || kHeadDim == 64) && (kHeadDimV == kHeadDim);
                     // Only needed here to decide if we should use cluster
                     static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap, Use_one_mma_wg)) : 128;
                     static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen && !Use_one_mma_wg;
@@ -222,7 +222,11 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
                             // Only use Cluster if number of tiles along seqlen_q is even and not varlen
                             CLUSTER_SWITCH(cutlass::ceil_div(params.seqlen_q * (!PackGQA ? 1 : params.h / params.h_k), kBlockM) % 2 == 0, Use_cluster, [&] {
                                 static constexpr int ClusterM = Enable_cluster && Use_cluster ? 2 : 1;
-                                run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor, Use_one_mma_wg>(params, stream);
+                                int const qhead_per_khead = !PackGQA ? 1 : cutlass::ceil_div(params.h, params.h_k);
+                                PACK_GQA_BLOCK_SWITCH(qhead_per_khead, kBlockH_, [&] {
+                                    static constexpr int kBlockH = 1; // FORCE kBlockH=1 to debug
+                                    run_flash_fwd<Arch, kHeadDim, kHeadDimV, ClusterM, T, T_out, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV && Varlen, HasQv, PackGQA, Split, V_colmajor, Use_one_mma_wg, kBlockH>(params, stream);
+                                });
                             });
                         });
                     });

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -30,7 +30,7 @@ using namespace cute;
 
 template <int Stages, class ClusterShape_, class TileShape_MNK_, int kHeadDimV, class Element_, class ElementAccum_, class ArchTag_,
         bool Is_causal_, bool Is_local_, bool Has_softcap_, bool Varlen_, bool PagedKVNonTMA_, bool AppendKV_, bool HasQv_,
-        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_>
+        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_, int kBlockH_=1>
 struct CollectiveMainloopFwdSm90 {
 
     static constexpr int kStages = Stages;
@@ -51,10 +51,11 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr bool AppendKV = AppendKV_;
     static constexpr bool HasQv = HasQv_;
     static constexpr bool PackGQA = PackGQA_;
+    static constexpr bool PackGQA_TMA = PackGQA && kBlockH_ > 1;
     static constexpr bool Split = Split_;
     static constexpr bool V_colmajor = V_colmajor_;
     static constexpr bool Transpose_V = Is_FP8 && !V_colmajor;
-    static constexpr bool Use_TMA_Q = !PackGQA;
+    static constexpr bool Use_TMA_Q = !PackGQA || PackGQA_TMA;
     static constexpr bool Use_TMA_KV = !PagedKVNonTMA;
     static_assert(Use_TMA_KV || CUTE_STATIC_V(size(ClusterShape{})) == 1, "If not using TMA for KV, ClusterShape must be 1");
     static_assert(Use_TMA_KV || !V_colmajor, "If not using TMA for KV, V_colmajor is not supported");
@@ -69,6 +70,7 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr int kBlockM = get<0>(TileShape_MNK{});
     static constexpr int kBlockN = get<1>(TileShape_MNK{});
     static constexpr int kHeadDim = get<2>(TileShape_MNK{});
+    static constexpr int kBlockH = kBlockH_;
 
     using SeqlenInfo_t = flash::SeqlenInfoQKNewK<Varlen, AppendKV>;
     using BlockMN_t = flash::BlockMN<SeqlenInfo_t, kBlockM, kBlockN, Is_causal, Is_local, PackGQA, Split>;
@@ -614,7 +616,10 @@ struct CollectiveMainloopFwdSm90 {
         int const bidh = get<1>(block_coord);
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        // Update seqlen_info using n_offset:
+        // offset_k -> offset_k + n_offset
+        // seqlen_k -> seqlen_k - n_offset
+        auto [n_block_min, n_block_max, n_offset] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);
@@ -668,8 +673,9 @@ struct CollectiveMainloopFwdSm90 {
 
         Tensor gQ = local_tile(domain_offset(make_coord(seqlen_info.offset_q, _0{}), mQ), select<0, 2>(TileShape_MNK{}), make_coord(m_block, _0{}));  // (M, K)
         // if (cute::thread0()) { printf("Varlen = %d, params.leftpad_k = %p, leftpad_k = %d\n", Varlen, params.leftpad_k, leftpad_k); }
-        Tensor gK_TMA = local_tile(domain_offset(make_coord(seqlen_info.offset_k, _0{}, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}, _));  // (N, K, _, _)
-        Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, seqlen_info.offset_k, _0{}), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _, _));  // (K, N, _, _)
+        // Now add n_offset to update KV gmem pointers
+        Tensor gK_TMA = local_tile(domain_offset(make_coord(seqlen_info.offset_k + n_offset, _0{}, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}, _));  // (N, K, _, _)
+        Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, seqlen_info.offset_k + n_offset, _0{}), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _, _));  // (K, N, _, _)
 
         auto block_tma_Q = params.tma_load_Q.get_slice(_0{});
         Tensor tQgQ = group_modes<0, 3>(block_tma_Q.partition_S(gQ));  // (TMA)
@@ -705,7 +711,7 @@ struct CollectiveMainloopFwdSm90 {
             params.ptr_K, params.shape_K, params.stride_K,
             params.ptr_V, params.headdim_v, params.stride_V,
             params.page_size_divmod, params.blockN_per_page_size_divmod,
-            bidb_kv, bidh_kv, thread_idx, seqlen_info.seqlen_k, seqlen_info.leftpad_k, bidb_kv_idx
+            bidb_kv, bidh_kv, thread_idx, seqlen_info.seqlen_k - n_offset, seqlen_info.leftpad_k + n_offset, bidb_kv_idx
         );
 
         // Set up for transposing V, only used if Transpose_V
@@ -983,7 +989,7 @@ struct CollectiveMainloopFwdSm90 {
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
         int const bidh_kv = !PackGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh;
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        auto [n_block_min, n_block_max, n_offset] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);
@@ -1065,7 +1071,11 @@ struct CollectiveMainloopFwdSm90 {
         };
 
         int const seqlen_q = seqlen_info.seqlen_q;
-        int const seqlen_k = seqlen_info.seqlen_k;
+        // Compute actual seqlen_k for this mma worktile
+        int const seqlen_k = seqlen_info.seqlen_k - n_offset;
+        // Precompute m_idx_min and m_idx_max for mask helper inlining (seqlen_k already adjusted by n_offset)
+        int const m_idx_min = !PackGQA ? m_block * kBlockM : params.qhead_per_khead_divmod.divide(m_block * kBlockM);
+        int const m_idx_max = !PackGQA ? (m_block + 1) * kBlockM : params.qhead_per_khead_divmod.divide((m_block + 1) * kBlockM - 1) + 1;
         int n_block = n_block_max - 1;
 
         flash::Mask<kBlockM, kBlockN, PackGQA, TiledMmaQK> mask(
@@ -1217,18 +1227,26 @@ struct CollectiveMainloopFwdSm90 {
 
             if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
                 auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-                int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
-                    seqlen_info, m_block, n_block_min, params.window_size_right,
-                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                int n_block_min_causal_local_mask;
+                {
+                    int const n_idx_cm = m_idx_min + seqlen_k - seqlen_q;
+                    int n_idx_right = !Is_local ? n_idx_cm : n_idx_cm + params.window_size_right;
+                    if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_right = std::min(n_idx_right, flash::round_up(params.attention_chunk_divmod, n_idx_cm)); } }
+                    n_block_min_causal_local_mask = std::max(n_block_min, n_idx_right / kBlockN);
+                }
                 #pragma unroll 1
                 for (; n_block >= n_block_min_causal_local_mask; --n_block) {
                     fwd_step(n_block, mask_fn, cute::true_type{} /*check_inf*/);
                 }
             }
 
-            int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
-                seqlen_info, m_block, n_block_min, params.window_size_left,
-                params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+            int n_block_min_before_local_mask;
+            {
+                int const n_idx_bm = m_idx_max + seqlen_k - seqlen_q;
+                int n_idx_left = !Is_local ? n_idx_bm : n_idx_bm - params.window_size_left;
+                if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_left = std::max(n_idx_left, flash::round_down(params.attention_chunk_divmod, n_idx_bm)); } }
+                n_block_min_before_local_mask = !Is_local ? n_block_min : std::max(n_block_min, cute::ceil_div(n_idx_left, kBlockN));
+            }
             auto no_mask_fn = [](auto& tSrS, int n_block) { };
             #pragma unroll 1
             for (; n_block >= n_block_min_before_local_mask; --n_block) {
@@ -1318,17 +1336,25 @@ struct CollectiveMainloopFwdSm90 {
             --n_block;
             if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
                 auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-                int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
-                    seqlen_info, m_block, n_block_min, params.window_size_right,
-                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                int n_block_min_causal_local_mask;
+                {
+                    int const n_idx_cm = m_idx_min + seqlen_k - seqlen_q;
+                    int n_idx_right = !Is_local ? n_idx_cm : n_idx_cm + params.window_size_right;
+                    if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_right = std::min(n_idx_right, flash::round_up(params.attention_chunk_divmod, n_idx_cm)); } }
+                    n_block_min_causal_local_mask = std::max(n_block_min, n_idx_right / kBlockN);
+                }
                 #pragma unroll 1
                 for (; n_block >= n_block_min_causal_local_mask; --n_block) {
                     fwd_step(n_block, mask_fn, cute::false_type{} /*is_first_iter*/, cute::true_type{} /*check_inf*/);
                 }
             }
-            int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
-                seqlen_info, m_block, n_block_min, params.window_size_left,
-                params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+            int n_block_min_before_local_mask;
+            {
+                int const n_idx_bm = m_idx_max + seqlen_k - seqlen_q;
+                int n_idx_left = !Is_local ? n_idx_bm : n_idx_bm - params.window_size_left;
+                if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_left = std::max(n_idx_left, flash::round_down(params.attention_chunk_divmod, n_idx_bm)); } }
+                n_block_min_before_local_mask = !Is_local ? n_block_min : std::max(n_block_min, cute::ceil_div(n_idx_left, kBlockN));
+            }
             auto no_mask_fn = [](auto& tSrS, int n_block) { };
             #pragma unroll 1
             for (; n_block >= n_block_min_before_local_mask; --n_block) {
@@ -1377,7 +1403,7 @@ struct CollectiveMainloopFwdSm90 {
         int const m_block = get<0>(block_coord);
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        auto [n_block_min, n_block_max, n_offset_pv] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);

--- a/hopper/static_switch.h
+++ b/hopper/static_switch.h
@@ -202,3 +202,22 @@
       return __VA_ARGS__();                                                                      \
     }                                                                                            \
   }()
+
+#ifdef FLASHATTENTION_DISABLE_PACKGQA
+  #define PACK_GQA_BLOCK_SWITCH(QHEADS_PER_KHEADS, BLOCK_H, ...)                                 \
+  [&] {                                                                                          \
+      constexpr static int BLOCK_H = 1;                                                          \
+      return __VA_ARGS__();                                                                      \
+  }()
+#else
+  #define PACK_GQA_BLOCK_SWITCH(QHEADS_PER_KHEADS, BLOCK_H, ...)                                 \
+  [&] {                                                                                          \
+    if (QHEADS_PER_KHEADS == 8) {                                                                \
+      constexpr static int BLOCK_H = 8;                                                          \
+      return __VA_ARGS__();                                                                      \
+    } else {                                                                                     \
+      constexpr static int BLOCK_H = 1;                                                          \
+      return __VA_ARGS__();                                                                      \
+    }                                                                                            \
+  }()
+#endif

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -23,9 +23,8 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
                 if (use_one_mma_wg) {
                     return {64, 192, true, true};
                 } else {
-                    // Switch to tile size 192 x 192 for now
-                    bool const use_blockN_128 = is_causal || is_local || paged_kv_non_TMA;
-                    return {192, use_blockN_128 ? 128 : 192, use_blockN_128, true};
+                    // kBlockN=160 benefits SWA when window length <= 128, keep IntraWGOverlap=true
+                    return {192, is_causal ? 128 : is_local || paged_kv_non_TMA ? 160 : 192, is_causal || is_local, true};
                 }
             }
             // Good for long seqlen (>= 4k) but suffers from tile quantization at short seqlen

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -23,8 +23,8 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
                 if (use_one_mma_wg) {
                     return {64, 192, true, true};
                 } else {
-                    // kBlockN=160 benefits SWA when window length <= 128, keep IntraWGOverlap=true
-                    return {192, is_causal ? 128 : is_local || paged_kv_non_TMA ? 160 : 192, is_causal || is_local, true};
+                    // kBlockN=160 benefits SWA when window length <= 128, set IntraWGOverlap=false for SWA (matches vLLM)
+                    return {192, is_causal ? 128 : is_local || paged_kv_non_TMA ? 160 : 192, is_causal || is_local, !is_local};
                 }
             }
             // Good for long seqlen (>= 4k) but suffers from tile quantization at short seqlen

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -23,8 +23,9 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
                 if (use_one_mma_wg) {
                     return {64, 192, true, true};
                 } else {
-                    // Benefits SWA when window length <= 128
-                    return {192, is_causal ? 128 : is_local || paged_kv_non_TMA ? 160 : 192, is_causal || is_local, !is_local};
+                    // Switch to tile size 192 x 192 for now
+                    bool const use_blockN_128 = is_causal || is_local || paged_kv_non_TMA;
+                    return {192, use_blockN_128 ? 128 : 192, use_blockN_128, true};
                 }
             }
             // Good for long seqlen (>= 4k) but suffers from tile quantization at short seqlen

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -23,9 +23,8 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
                 if (use_one_mma_wg) {
                     return {64, 192, true, true};
                 } else {
-                    // Switch to tile size 192 x 192 for now
-                    bool const use_blockN_128 = is_causal || is_local || paged_kv_non_TMA;
-                    return {192, use_blockN_128 ? 128 : 192, use_blockN_128, true};
+                    // Benefits SWA when window length <= 128
+                    return {192, is_causal ? 128 : is_local || paged_kv_non_TMA ? 160 : 192, is_causal || is_local, !is_local};
                 }
             }
             // Good for long seqlen (>= 4k) but suffers from tile quantization at short seqlen


### PR DESCRIPTION
## Summary

Adapt the n_offset sliding window optimization from vllm for sgl-attn. This optimization shifts KV gmem pointers to the start of the sliding window and reduces seqlen_k, so the kernel only iterates over actual window blocks instead of the full KV sequence length.

## Changes

### Core optimization (block.h, mainloop_fwd_sm90_tma_gmma_ws.hpp)
- Compute `n_offset` in `get_n_block_min_max()` to identify where the sliding window starts
- Return n_offset as part of 3-tuple from `get_n_block_min_max()`
- In `load()`: shift KV TMA pointers by n_offset so we start reading from the window start
- In `mma()`: adjust seqlen_k by subtracting n_offset, inline mask helper functions for compatibility with const seqlen_k in `SeqlenInfoQK`
- In `mma_pv()`: handle 3-tuple return from `get_n_block_min_max()`

### Tile size tuning (tile_size.h)
- Use kBlockN=160 with IntraWGOverlap=false for SWA with hdim<=64

### API changes (flash_api.cpp)
- Disable PagedKV TMA for is_local (required for n_offset pointer shifting)
- Add PackGQA override for hdim=64, h/h_k=8, is_local

### Template infrastructure (epilogue_fwd.hpp, flash_fwd_launch_template.h, static_switch.h)
- Add kBlockH template parameter (infrastructure for future PackGQA_TMA support)
- Add PACK_GQA_BLOCK_SWITCH macro
- kBlockH forced to 1 for now (see Known Limitations)

## Performance

Benchmarked on gpt-oss-120b (hdim=64, SWA=128, TP1, H200):
- **Before**: 9.84ms TPOT
- **After**: 9.35ms TPOT (~5% improvement)
- Benchmark: 16 concurrent requests, 1K input tokens, 12K output tokens
- Correctness verified: GSM8K accuracy 85.5% (matches baseline)

## Known Limitations

- `kBlockH` is forced to 1, which disables PackGQA_TMA. Enabling kBlockH > 1 requires validating sgl-attn epilogue with TMA-based Q/O access patterns (this caused correctness issues during testing).
- The n_offset optimization only activates for `is_local` (sliding window) attention layers.

## Test Plan

- [x] Build succeeds (ninja -j32, 372 targets)
- [x] GSM8K accuracy: 85.5% (verified correct output)
- [x] TPOT benchmark: 9.35ms (5% improvement over 9.84ms baseline)
- [x] vLLM same-node baseline: 9.12ms (remaining gap ~2.5%)
