### PR TITLE
Optimize SWA decode with n_offset and enabling one_mma_wg

### DIFF
--- a/hopper/block.h
+++ b/hopper/block.h
@@ -11,28 +11,18 @@ struct BlockMN {
 
     static
     CUTLASS_DEVICE
-    cute::tuple<int, int> get_n_block_min_max(
+    cute::tuple<int, int, int> get_n_block_min_max(
             SeqlenInfo_t const& seqlen_info,
             int const m_block, int const bidb, int const split_idx, int const num_splits,
             int const window_size_left, int const window_size_right,
             cutlass::FastDivmod const& attention_chunk_divmod,
             cutlass::FastDivmod const& qhead_per_khead_divmod) {
 
-        int const seqlen_k = seqlen_info.seqlen_k;
+        int seqlen_k = seqlen_info.seqlen_k;
         int const seqlen_q = seqlen_info.seqlen_q;
-        int n_block_max = cute::ceil_div(seqlen_k, kBlockN);
-        if constexpr (Is_causal || Is_local) {
-            int m_idx_max = (m_block + 1) * kBlockM;
-            // TODO: check off-by-1 error
-            if (PackGQA) { m_idx_max = qhead_per_khead_divmod.divide(m_idx_max - 1) + 1 ; }
-            int const n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q;
-            int n_idx_right = !Is_local ? n_idx : n_idx + window_size_right;
-            if (Is_local && attention_chunk_divmod.divisor > 0) {
-                n_idx_right = std::min(n_idx_right, flash::round_up(attention_chunk_divmod, n_idx));
-            }
-            n_block_max = std::min(n_block_max, cute::ceil_div(n_idx_right, kBlockN));
-        }
-        int n_block_min = 0;
+        int n_offset = 0;
+
+        // If local, calculate n_offset and update seqlen_k
         if constexpr (Is_local) {
             int m_idx_min = m_block * kBlockM;
             if (PackGQA) { m_idx_min = qhead_per_khead_divmod.divide(m_idx_min); }
@@ -41,8 +31,23 @@ struct BlockMN {
             if (attention_chunk_divmod.divisor > 0) {
                 n_idx_left = std::max(n_idx_left, flash::round_down(attention_chunk_divmod, n_idx));
             }
-            n_block_min = std::max(int(0), n_idx_left / kBlockN);
+            // unlike previously, we don't divide by kBlockN because we want offset for seqlen_k
+            n_offset = std::max(int(0), n_idx_left);
+            // Subtract n_offset from seqlen_k for subsequent calculations such as n_block_max
+            seqlen_k -= n_offset;
         }
+
+        int n_block_max = cute::ceil_div(seqlen_k, kBlockN);
+        if constexpr (Is_causal || Is_local) {
+            int m_idx_max = (m_block + 1) * kBlockM;
+            // TODO: check off-by-1 error
+            if (PackGQA) { m_idx_max = qhead_per_khead_divmod.divide(m_idx_max - 1) + 1 ; }
+            // If local, blocking (m_idx_max - m_idx_min + window_size_right + window_size_left)
+            n_block_max = std::min(n_block_max,
+                                   cute::ceil_div(m_idx_max + seqlen_k - seqlen_q + window_size_right, kBlockN));
+        }
+        // Now, only adjust n_block_min if split
+        int n_block_min = 0;
         // if (threadIdx.x == 128) { printf("Inside, bid.x = %d, bid.y = %d, bid.z = %d, split_idx = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.x, blockIdx.y, blockIdx.z, split_idx, n_block_min, n_block_max); }
         if constexpr (Split) {
             uint32_t num_splits_dynamic_u = reinterpret_cast<uint32_t const&>(split_idx) >> 16; // first 16 bits are for num_splits
@@ -55,7 +60,8 @@ struct BlockMN {
             // if (threadIdx.x == 128) { printf("Inside, bid.x = %d, bid.y = %d, bid.z = %d, split_idx = %d, num_splits_dynamic = %d, num_splits_actual = %d, num_n_blocks_per_split = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.x, blockIdx.y, blockIdx.z, split_idx, num_splits_dynamic, num_splits_actual, num_n_blocks_per_split, n_block_min, n_block_max); }
         }
         // if (threadIdx.x == 128) { printf("After split, inside, bid.y = %d, bid.z = %d, split_idx = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.y, blockIdx.z, split_idx, n_block_min, n_block_max); }
-        return {n_block_min, n_block_max};
+        // Return n_offset to add to KV gmem pointers and use in masks
+        return {n_block_min, n_block_max, n_offset};
     }
 
     static
@@ -67,11 +73,12 @@ struct BlockMN {
             cutlass::FastDivmod const& attention_chunk_divmod,
             cutlass::FastDivmod const& qhead_per_khead_divmod) {
 
-        auto [n_block_min, n_block_max] = get_n_block_min_max(
+        // TODO: check logic with n_offset
+        auto [n_block_min, n_block_max, n_offset] = get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, num_splits,
             window_size_left, window_size_right, attention_chunk_divmod, qhead_per_khead_divmod);
-        int const idx_k_new_min = std::max(n_block_min * kBlockN - seqlen_info.seqlen_k_og, 0);
-        int const idx_k_new_max = std::min(n_block_max * kBlockN - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new);
+        int const idx_k_new_min = std::max(n_block_min * kBlockN + n_offset - seqlen_info.seqlen_k_og, 0);
+        int const idx_k_new_max = std::min(n_block_max * kBlockN + n_offset - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new);
         int const n_block_new_min = idx_k_new_min / kBlockN;
         int const n_block_new_max = idx_k_new_max > idx_k_new_min ? cute::ceil_div(idx_k_new_max, kBlockN) : n_block_new_min;
         // if (threadIdx.x == 128 && m_block == 0) { printf("bidb = %d, seqlen_k_new = %d, seqlen_k_og = %d, n_block_min = %d, n_block_max = %d, idx_k_new_min = %d, idx_k_new_max = %d, n_block_new_min = %d, n_block_new_max = %d\n", bidb, seqlen_k_new, seqlen_k_og, n_block_min, n_block_max, idx_k_new_min, idx_k_new_max, n_block_new_min, n_block_new_max);}

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -393,7 +393,7 @@ void run_mha_fwd_combine(Flash_fwd_params &params, cudaStream_t stream, bool ena
 }
 
 inline bool get_pagedkv_tma(Flash_fwd_params const& params) {
-    if (params.arch < 90 || !params.page_table || params.leftpad_k || params.knew_ptr) { return false; }
+    if (params.arch < 90 || !params.page_table || params.leftpad_k || params.knew_ptr || params.is_local) { return false; }
     // This needs to match the kernel configs
     auto kBlockMN_kernel_args_sm90 = tile_size_fwd_sm90(params.d_rounded, params.dv_rounded, params.is_causal, params.is_local, params.is_e4m3 ? 1 : 2 /*element_size*/, false /*v_colmajor*/, false /*paged_kv_non_TMA*/, params.softcap > 0.f, use_one_mma_wg(params));
     int const kBlockM = std::get<0>(kBlockMN_kernel_args_sm90);

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -211,8 +211,8 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
             static constexpr bool V_colmajor = V_colmajor_ && sizeof(T) == 1;
             VARLEN_SWITCH(params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k, Varlen, [&] {
                 BOOL_SWITCH(use_one_mma_wg(params), Use_one_mma_wg_, [&] {
-                    // Only enable for headdim 64/128 on Hopper with same Q/K and V headdim, non-local
-                    static constexpr bool Use_one_mma_wg = Use_one_mma_wg_ && Arch >= 90 && (kHeadDim == 128 || kHeadDim == 64) && (kHeadDimV == kHeadDim) && !Is_local;
+                    // Only enable for headdim 64/128 on Hopper with same Q/K and V headdim
+                    static constexpr bool Use_one_mma_wg = Use_one_mma_wg_ && Arch >= 90 && (kHeadDim == 128 || kHeadDim == 64) && (kHeadDimV == kHeadDim);
                     // Only needed here to decide if we should use cluster
                     static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap, Use_one_mma_wg)) : 128;
                     static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen && !Use_one_mma_wg;

--- a/hopper/heuristics.h
+++ b/hopper/heuristics.h
@@ -10,7 +10,7 @@
 inline bool use_one_mma_wg(Flash_fwd_params const& params) {
     // Use 1 MMA warp group instead of 2-3 when effective Q length is small.
     // This gives better perf for decode / small-batch scenarios on Hopper.
-    return params.arch >= 90 && (params.d == 128 || params.d == 64) && !params.is_local &&
+    return params.arch >= 90 && (params.d == 128 || params.d == 64) &&
         params.seqlen_q * (params.h / params.h_k) <= 64;
 };
 

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -30,7 +30,7 @@ using namespace cute;
 
 template <int Stages, class ClusterShape_, class TileShape_MNK_, int kHeadDimV, class Element_, class ElementAccum_, class ArchTag_,
         bool Is_causal_, bool Is_local_, bool Has_softcap_, bool Varlen_, bool PagedKVNonTMA_, bool AppendKV_, bool HasQv_,
-        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_>
+        bool MmaPV_is_RS, bool IntraWGOverlap, bool PackGQA_, bool Split_, bool V_colmajor_, class ElementSink_, int kBlockH_=1>
 struct CollectiveMainloopFwdSm90 {
 
     static constexpr int kStages = Stages;
@@ -51,10 +51,11 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr bool AppendKV = AppendKV_;
     static constexpr bool HasQv = HasQv_;
     static constexpr bool PackGQA = PackGQA_;
+    static constexpr bool PackGQA_TMA = PackGQA && kBlockH_ > 1;
     static constexpr bool Split = Split_;
     static constexpr bool V_colmajor = V_colmajor_;
     static constexpr bool Transpose_V = Is_FP8 && !V_colmajor;
-    static constexpr bool Use_TMA_Q = !PackGQA;
+    static constexpr bool Use_TMA_Q = !PackGQA || PackGQA_TMA;
     static constexpr bool Use_TMA_KV = !PagedKVNonTMA;
     static_assert(Use_TMA_KV || CUTE_STATIC_V(size(ClusterShape{})) == 1, "If not using TMA for KV, ClusterShape must be 1");
     static_assert(Use_TMA_KV || !V_colmajor, "If not using TMA for KV, V_colmajor is not supported");
@@ -69,6 +70,7 @@ struct CollectiveMainloopFwdSm90 {
     static constexpr int kBlockM = get<0>(TileShape_MNK{});
     static constexpr int kBlockN = get<1>(TileShape_MNK{});
     static constexpr int kHeadDim = get<2>(TileShape_MNK{});
+    static constexpr int kBlockH = kBlockH_;
 
     using SeqlenInfo_t = flash::SeqlenInfoQKNewK<Varlen, AppendKV>;
     using BlockMN_t = flash::BlockMN<SeqlenInfo_t, kBlockM, kBlockN, Is_causal, Is_local, PackGQA, Split>;
@@ -614,7 +616,10 @@ struct CollectiveMainloopFwdSm90 {
         int const bidh = get<1>(block_coord);
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        // Update seqlen_info using n_offset:
+        // offset_k -> offset_k + n_offset
+        // seqlen_k -> seqlen_k - n_offset
+        auto [n_block_min, n_block_max, n_offset] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);
@@ -668,8 +673,9 @@ struct CollectiveMainloopFwdSm90 {
 
         Tensor gQ = local_tile(domain_offset(make_coord(seqlen_info.offset_q, _0{}), mQ), select<0, 2>(TileShape_MNK{}), make_coord(m_block, _0{}));  // (M, K)
         // if (cute::thread0()) { printf("Varlen = %d, params.leftpad_k = %p, leftpad_k = %d\n", Varlen, params.leftpad_k, leftpad_k); }
-        Tensor gK_TMA = local_tile(domain_offset(make_coord(seqlen_info.offset_k, _0{}, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}, _));  // (N, K, _, _)
-        Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, seqlen_info.offset_k, _0{}), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _, _));  // (K, N, _, _)
+        // Now add n_offset to update KV gmem pointers
+        Tensor gK_TMA = local_tile(domain_offset(make_coord(seqlen_info.offset_k + n_offset, _0{}, _0{}), mK_TMA), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}, _));  // (N, K, _, _)
+        Tensor gVt_TMA = local_tile(domain_offset(make_coord(_0{}, seqlen_info.offset_k + n_offset, _0{}), mVt_TMA), select<1, 2>(TileShape_MNK_PV{}), make_coord(_0{}, _, _));  // (K, N, _, _)
 
         auto block_tma_Q = params.tma_load_Q.get_slice(_0{});
         Tensor tQgQ = group_modes<0, 3>(block_tma_Q.partition_S(gQ));  // (TMA)
@@ -705,7 +711,7 @@ struct CollectiveMainloopFwdSm90 {
             params.ptr_K, params.shape_K, params.stride_K,
             params.ptr_V, params.headdim_v, params.stride_V,
             params.page_size_divmod, params.blockN_per_page_size_divmod,
-            bidb_kv, bidh_kv, thread_idx, seqlen_info.seqlen_k, seqlen_info.leftpad_k, bidb_kv_idx
+            bidb_kv, bidh_kv, thread_idx, seqlen_info.seqlen_k - n_offset, seqlen_info.leftpad_k + n_offset, bidb_kv_idx
         );
 
         // Set up for transposing V, only used if Transpose_V
@@ -983,7 +989,7 @@ struct CollectiveMainloopFwdSm90 {
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
         int const bidh_kv = !PackGQA ? params.qhead_per_khead_divmod.divide(bidh) : bidh;
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        auto [n_block_min, n_block_max, n_offset] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);
@@ -1065,7 +1071,11 @@ struct CollectiveMainloopFwdSm90 {
         };
 
         int const seqlen_q = seqlen_info.seqlen_q;
-        int const seqlen_k = seqlen_info.seqlen_k;
+        // Compute actual seqlen_k for this mma worktile
+        int const seqlen_k = seqlen_info.seqlen_k - n_offset;
+        // Precompute m_idx_min and m_idx_max for mask helper inlining (seqlen_k already adjusted by n_offset)
+        int const m_idx_min = !PackGQA ? m_block * kBlockM : params.qhead_per_khead_divmod.divide(m_block * kBlockM);
+        int const m_idx_max = !PackGQA ? (m_block + 1) * kBlockM : params.qhead_per_khead_divmod.divide((m_block + 1) * kBlockM - 1) + 1;
         int n_block = n_block_max - 1;
 
         flash::Mask<kBlockM, kBlockN, PackGQA, TiledMmaQK> mask(
@@ -1217,18 +1227,26 @@ struct CollectiveMainloopFwdSm90 {
 
             if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
                 auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-                int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
-                    seqlen_info, m_block, n_block_min, params.window_size_right,
-                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                int n_block_min_causal_local_mask;
+                {
+                    int const n_idx_cm = m_idx_min + seqlen_k - seqlen_q;
+                    int n_idx_right = !Is_local ? n_idx_cm : n_idx_cm + params.window_size_right;
+                    if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_right = std::min(n_idx_right, flash::round_up(params.attention_chunk_divmod, n_idx_cm)); } }
+                    n_block_min_causal_local_mask = std::max(n_block_min, n_idx_right / kBlockN);
+                }
                 #pragma unroll 1
                 for (; n_block >= n_block_min_causal_local_mask; --n_block) {
                     fwd_step(n_block, mask_fn, cute::true_type{} /*check_inf*/);
                 }
             }
 
-            int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
-                seqlen_info, m_block, n_block_min, params.window_size_left,
-                params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+            int n_block_min_before_local_mask;
+            {
+                int const n_idx_bm = m_idx_max + seqlen_k - seqlen_q;
+                int n_idx_left = !Is_local ? n_idx_bm : n_idx_bm - params.window_size_left;
+                if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_left = std::max(n_idx_left, flash::round_down(params.attention_chunk_divmod, n_idx_bm)); } }
+                n_block_min_before_local_mask = !Is_local ? n_block_min : std::max(n_block_min, cute::ceil_div(n_idx_left, kBlockN));
+            }
             auto no_mask_fn = [](auto& tSrS, int n_block) { };
             #pragma unroll 1
             for (; n_block >= n_block_min_before_local_mask; --n_block) {
@@ -1318,17 +1336,25 @@ struct CollectiveMainloopFwdSm90 {
             --n_block;
             if constexpr (Is_causal || Is_local) { // Separate iterations with causal or local masking
                 auto mask_fn = [&](auto& tSrS, int n_block) { mask.template apply<false /*Seqlenk_mask*/, Is_causal, Is_local>(tSrS, m_block, n_block); };
-                int const n_block_min_causal_local_mask = BlockMN_t::get_n_block_min_causal_local_mask(
-                    seqlen_info, m_block, n_block_min, params.window_size_right,
-                    params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+                int n_block_min_causal_local_mask;
+                {
+                    int const n_idx_cm = m_idx_min + seqlen_k - seqlen_q;
+                    int n_idx_right = !Is_local ? n_idx_cm : n_idx_cm + params.window_size_right;
+                    if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_right = std::min(n_idx_right, flash::round_up(params.attention_chunk_divmod, n_idx_cm)); } }
+                    n_block_min_causal_local_mask = std::max(n_block_min, n_idx_right / kBlockN);
+                }
                 #pragma unroll 1
                 for (; n_block >= n_block_min_causal_local_mask; --n_block) {
                     fwd_step(n_block, mask_fn, cute::false_type{} /*is_first_iter*/, cute::true_type{} /*check_inf*/);
                 }
             }
-            int const n_block_min_before_local_mask = BlockMN_t::get_n_block_min_before_local_mask(
-                seqlen_info, m_block, n_block_min, params.window_size_left,
-                params.attention_chunk_divmod, params.qhead_per_khead_divmod);
+            int n_block_min_before_local_mask;
+            {
+                int const n_idx_bm = m_idx_max + seqlen_k - seqlen_q;
+                int n_idx_left = !Is_local ? n_idx_bm : n_idx_bm - params.window_size_left;
+                if constexpr (Is_local) { if (params.attention_chunk_divmod.divisor > 0) { n_idx_left = std::max(n_idx_left, flash::round_down(params.attention_chunk_divmod, n_idx_bm)); } }
+                n_block_min_before_local_mask = !Is_local ? n_block_min : std::max(n_block_min, cute::ceil_div(n_idx_left, kBlockN));
+            }
             auto no_mask_fn = [](auto& tSrS, int n_block) { };
             #pragma unroll 1
             for (; n_block >= n_block_min_before_local_mask; --n_block) {
@@ -1377,7 +1403,7 @@ struct CollectiveMainloopFwdSm90 {
         int const m_block = get<0>(block_coord);
         int const bidb = get<2>(block_coord);
         int const split_idx = get<3>(block_coord);
-        auto [n_block_min, n_block_max] = BlockMN_t::get_n_block_min_max(
+        auto [n_block_min, n_block_max, n_offset_pv] = BlockMN_t::get_n_block_min_max(
             seqlen_info, m_block, bidb, split_idx, params.num_splits,
             params.window_size_left, params.window_size_right, params.attention_chunk_divmod,
             params.qhead_per_khead_divmod);

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -24,7 +24,7 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
                     return {64, 192, true, true};
                 } else {
                     // Switch to tile size 192 x 192 for now
-                    bool const use_blockN_128 = is_causal || is_local || paged_kv_non_TMA;
+                    bool const use_blockN_128 = is_causal || (!is_local && paged_kv_non_TMA);
                     return {192, use_blockN_128 ? 128 : 192, use_blockN_128, true};
                 }
             }


### PR DESCRIPTION
## Summary

Optimize SWA (local attention) decode performance with two complementary changes:

1. **n_offset + kBlockN=192**: Align SWA window start and use larger KV block size so the window (129 tokens for SWA=128) fits in a single block instead of 2.
2. **Enable use_one_mma_wg for SWA**: Remove `!is_local` guards so SWA decode uses the 1-MMA-warp-group path (kBlockM=64 instead of 192), matching vLLM's approach. Safe because the mainloop already handles Is_local masking in both IntraWGOverlap and !IntraWGOverlap paths.

## Benchmark

Model: gpt-oss-120b (hdim=64, h/h_k=8, SWA=128, bf16), 1×H200,
SGLang bench_serving with 16 prompts, input_len=1000, output_len=12000.

| Metric | Baseline | n_offset + kBlockN=192 | + use_one_mma_wg | Total Change |
|--------|----------|----------------------|------------------|--------------|
| Output throughput (tok/s) | 1624.89 | 1684.62 | 1700.50 | **+4.7%** |
| Mean TPOT (ms) | 9.80 | 9.53 | 9.35 | **-4.6%** |
| Median ITL (ms) | 9.67 | 9.26 | 9.17 | **-5.2%** |
| GSM8K Accuracy (200q) | 86.5% | 87.0% | 86.5% | ✅ |


SWA FA kernel in one decoder layer
main:
<img width="1294" height="314" alt="image" src="https://github.com/user-attachments/assets/a7dc15bc-c54e-4ef8-baaa-f675194d6534" />

this PR:
<img width="969" height="198" alt="image" src="https://github.com/user-attachments/assets/926d5d28-c41f-4822-86cf-b06dd2dd4ee7" />
