### PR TITLE
Add batch_invariant flag for deterministic split-KV scheduling

### DIFF
--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -165,7 +165,9 @@ struct Flash_fwd_params : public Qkv_params {
 
     int arch;
     int num_sm;
-    
+
+    bool batch_invariant = false;
+
     // Learnable sink
     void *__restrict__ sink_ptr;
     int * __restrict__ sparse_mask_fine;

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -690,7 +690,8 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         std::optional<bool> pack_gqa_,
         int64_t sm_margin,
         std::optional<const at::Tensor> &sinks_, // (h)
-        std::optional<at::Tensor> sparse_mask_fine_   // [total_q, max_k_blocks, num_int32_per_block]
+        bool batch_invariant = false,
+        std::optional<at::Tensor> sparse_mask_fine_ = std::nullopt   // [total_q, max_k_blocks, num_int32_per_block]
         ) {
 
     auto dprops = at::cuda::getCurrentDeviceProperties();
@@ -967,6 +968,7 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
 
     params.pagedkv_tma = get_pagedkv_tma(params);
     params.num_splits = num_splits <= 0 ? get_num_splits(params) : num_splits;
+    params.batch_invariant = batch_invariant;
     // Always enable PackGQA for Split, and get_pack_gqa requires params.num_splits to decide
     params.pack_gqa = pack_gqa_.has_value() ? pack_gqa_.value() : get_pack_gqa(params);
 

--- a/hopper/flash_prepare_scheduler.cu
+++ b/hopper/flash_prepare_scheduler.cu
@@ -55,7 +55,8 @@ __global__ void prepare_varlen_num_blocks_kernel(
         bool enable_pdl,
         bool is_causal,
         bool packgqa,
-        int max_kvblocks_in_l2) {
+        int max_kvblocks_in_l2,
+        bool batch_invariant) {
 
     static constexpr int kNumBatchPerWarp = cutlass::NumThreadsPerWarp - 1;
     static constexpr int kSmemSize = 1;
@@ -138,7 +139,14 @@ __global__ void prepare_varlen_num_blocks_kernel(
     };
     
     int num_splits_dynamic;
-    if (int(gridDim.x) > 1 || num_splits_static == 1) {
+    if (batch_invariant) {
+        // When batch_invariant, use static num_splits for all batches so that split
+        // boundaries depend only on per-sequence properties, not batch composition.
+        num_splits_dynamic = num_splits_static;
+        if (num_splits_dynamic > 1 && int(gridDim.x) == 1) {
+            num_n_blocks = cutlass::ceil_div(num_n_blocks, num_splits_dynamic);
+        }
+    } else if (int(gridDim.x) > 1 || num_splits_static == 1) {
         // set num splits for all batches to 1 (note that user expects num_splits_static to mean upper bound on splits)
         // for batch size > 992, we expect GPU occupancy to not be an issue except in degenerate cases (e.g., most are zero-length)
         num_splits_dynamic = 1;
@@ -157,7 +165,7 @@ __global__ void prepare_varlen_num_blocks_kernel(
         // blocks_per_sm = std::max(1, blocks_per_sm);  // 1 is the minimum number of blocks per SM
         num_splits_dynamic = std::max(std::min((num_n_blocks + blocks_per_sm - 1) / blocks_per_sm, num_splits_static), 1);
         // num_n_blocks per work tile for the batch
-        num_n_blocks = cutlass::ceil_div(num_n_blocks, num_splits_dynamic); 
+        num_n_blocks = cutlass::ceil_div(num_n_blocks, num_splits_dynamic);
     }
 
     if constexpr (Sort) {
@@ -244,7 +252,8 @@ void prepare_varlen_num_blocks(Flash_fwd_params &params, cudaStream_t stream, bo
                 enable_pdl,
                 params.is_causal,
                 packgqa,
-                max_kvblocks_in_l2);
+                max_kvblocks_in_l2,
+                params.batch_invariant);
         });
     });
 }

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -1261,3 +1261,138 @@ def test_flash3_bw_compatibility() -> None:
         "int attention_chunk=0, bool has_softcap=False, int num_splits=0, bool? pack_gqa=None, "
         "int sm_margin=0) -> Tensor"
     ))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+# MHA (nheads_k == nheads) excluded: pre-existing PackGQA precision issue with num_splits > 1
+@pytest.mark.parametrize("mha_type", ["gqa"])
+@pytest.mark.parametrize("num_splits", [1, 2, 4])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("varlen_q", [False, True])
+@pytest.mark.parametrize("d", [128])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (1, 339),
+        (3, 1024),
+        (64, 800),
+        (64, 2048),
+        (128, 128),
+        (256, 512),
+        (2048, 3577),
+    ],
+)
+def test_flash_attn_deterministic_num_splits(
+    seqlen_q,
+    seqlen_k,
+    d,
+    varlen_q,
+    causal,
+    num_splits,
+    mha_type,
+    dtype,
+):
+    """Test that flash attention output with static num_splits is batch-invariant.
+
+    Running with batch_size=5 vs batch_size=7 (where first 5 are identical)
+    should produce bit-exact outputs for the first 5 batches. This validates
+    that the scheduler assigns deterministic split boundaries regardless of
+    batch composition — critical for deterministic inference with num_splits > 1.
+    """
+    device = "cuda"
+    torch.random.manual_seed(0)
+    batch_size_1 = 5
+    batch_size_2 = 7
+    nheads = 6
+    nheads_k = nheads if mha_type == "mha" else (1 if mha_type == "mqa" else 3)
+    dv = d
+
+    q1 = torch.randn(batch_size_1, seqlen_q, nheads, d, device=device, dtype=dtype)
+    q2 = torch.cat([
+        q1.clone(),
+        torch.randn(batch_size_2 - batch_size_1, seqlen_q, nheads, d, device=device, dtype=dtype),
+    ], dim=0)
+
+    if varlen_q:
+        query_padding_mask_1 = generate_random_padding_mask(
+            seqlen_q, batch_size_1, device, mode="random"
+        )
+        q_unpad_1, indices_q_1, cu_seqlens_q_1, max_seqlen_q_1, *_ = unpad_input(
+            q1, query_padding_mask_1
+        )
+        output_pad_fn_1 = lambda output_unpad: pad_input(
+            output_unpad, indices_q_1, batch_size_1, seqlen_q
+        )
+
+        query_padding_mask_2_extra = generate_random_padding_mask(
+            seqlen_q, batch_size_2 - batch_size_1, device, mode="random"
+        )
+        query_padding_mask_2 = torch.cat(
+            [query_padding_mask_1.clone(), query_padding_mask_2_extra], dim=0
+        )
+        q_unpad_2, indices_q_2, cu_seqlens_q_2, max_seqlen_q_2, *_ = unpad_input(
+            q2, query_padding_mask_2
+        )
+        output_pad_fn_2 = lambda output_unpad: pad_input(
+            output_unpad, indices_q_2, batch_size_2, seqlen_q
+        )
+    else:
+        q_unpad_1, cu_seqlens_q_1, max_seqlen_q_1 = q1, None, None
+        q_unpad_2, cu_seqlens_q_2, max_seqlen_q_2 = q2, None, None
+        output_pad_fn_1 = output_pad_fn_2 = lambda x: x
+
+    k_cache_2 = torch.randn(
+        batch_size_2, seqlen_k, nheads_k, d, device=device, dtype=dtype
+    )
+    v_cache_2 = torch.randn(
+        batch_size_2, seqlen_k, nheads_k, dv, device=device, dtype=dtype
+    )
+    k_cache_1 = k_cache_2[:batch_size_1]
+    v_cache_1 = v_cache_2[:batch_size_1]
+
+    cache_seqlens_1 = torch.randint(
+        1, seqlen_k + 1, (batch_size_1,), dtype=torch.int32, device=device
+    )
+    cache_seqlens_2 = torch.cat([
+        cache_seqlens_1,
+        torch.randint(
+            1, seqlen_k + 1, (batch_size_2 - batch_size_1,),
+            dtype=torch.int32, device=device,
+        ),
+    ], dim=0)
+
+    out1, lse1, *_ = flash_attn_with_kvcache(
+        q_unpad_1,
+        k_cache_1,
+        v_cache_1,
+        cache_seqlens=cache_seqlens_1,
+        cu_seqlens_q=cu_seqlens_q_1,
+        max_seqlen_q=max_seqlen_q_1,
+        causal=causal,
+        num_splits=num_splits,
+        return_softmax_lse=True,
+        batch_invariant=True,
+    )
+    if varlen_q:
+        out1 = output_pad_fn_1(out1)
+
+    out2, lse2, *_ = flash_attn_with_kvcache(
+        q_unpad_2,
+        k_cache_2,
+        v_cache_2,
+        cache_seqlens=cache_seqlens_2,
+        cu_seqlens_q=cu_seqlens_q_2,
+        max_seqlen_q=max_seqlen_q_2,
+        causal=causal,
+        num_splits=num_splits,
+        return_softmax_lse=True,
+        batch_invariant=True,
+    )
+    if varlen_q:
+        out2 = output_pad_fn_2(out2)
+
+    assert torch.equal(out1, out2[:batch_size_1]), (
+        f"Outputs differ with num_splits={num_splits}: "
+        f"max diff = {(out1 - out2[:batch_size_1]).abs().max().item()}"
+    )


### PR DESCRIPTION
## Summary

When using `num_splits > 1` in varlen attention, the scheduler's occupancy-based heuristic computes `num_splits_dynamic` from a warp-sum of total blocks across **all batches** in the CTA. This makes split boundaries batch-dependent — the same sequence gets different split counts depending on other sequences in the batch, breaking deterministic inference.

This PR adds a `batch_invariant` flag that bypasses the dynamic heuristic and uses `num_splits_static` directly for all batches, guaranteeing split boundaries depend only on per-sequence properties.

## Changes

- **`flash.h`**: Add `batch_invariant` field to `Flash_fwd_params`
- **`flash_prepare_scheduler.cu`**: Gate the dynamic `num_splits` heuristic on `!batch_invariant`; when `batch_invariant=true`, set `num_splits_dynamic = num_splits_static` for all batches
- **`flash_api.cpp`**: Plumb `batch_invariant` through `mha_fwd`
- **`test_flash_attn.py`**: Batch-invariance test (96 cases, all passing)

## Test results

96/96 pass. MHA (`nheads_k == nheads`) excluded from the test due to a pre-existing PackGQA precision issue with `num_splits > 1` (confirmed on main branch — not introduced by this PR).

## Known issue

MHA + `num_splits > 1` is not batch-invariant even on the main branch (max diff ~0.002 in bf16). This is a pre-existing kernel issue where PackGQA (auto-enabled for splits) causes non-determinism in the MHA path. All GQA/MQA cases pass.