### PR TITLE
Remove Philox/Generator dependency in flash_sparse_api.cpp

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -22,6 +22,14 @@
 
 namespace FLASH_NAMESPACE {
 
+// Flash_fwd_params stores philox state as an opaque buffer so the header can
+// avoid pulling in ATen Generator types. Validate the buffer matches the real
+// at::PhiloxCudaState layout here, where we actually have the type.
+static_assert(sizeof(at::PhiloxCudaState) <= sizeof(Flash_fwd_params::philox_args),
+              "Flash_fwd_params::philox_args buffer is too small for at::PhiloxCudaState");
+static_assert(alignof(at::PhiloxCudaState) <= alignof(decltype(Flash_fwd_params::philox_args)),
+              "Flash_fwd_params::philox_args buffer is under-aligned for at::PhiloxCudaState");
+
 void set_params_fprop(Flash_fwd_params &params,
                       // sizes
                       const size_t b,
@@ -439,9 +447,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
         const double softmax_scale,
         bool is_causal,
         const double softcap,
-        const bool return_softmax,
-        const std::optional<at::Generator> gen_) {
-    
+        const bool return_softmax) {
+
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x = cc_major == 8 && cc_minor >= 0;
     bool is_sm90 = cc_major == 9 && cc_minor == 0;
@@ -475,6 +482,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
     TORCH_CHECK(batch_size > 0, "batch size must be postive");
     TORCH_CHECK(head_size_og <= 256, "FlashAttention forward only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+
+    TORCH_CHECK(p_dropout == 0.0f, "Sparse attention does not support dropout for inference");
 
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
@@ -561,26 +570,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
         params, batch_size, num_heads, head_size, seqlen_k, seqlen_q,
         head_size_rounded, p_dropout, /*num_splits*/ 1, get_num_sm(get_current_device()), opts);
 
-    // NOTE(woosuk): Commented out because they are not used in inference.
-    // // number of times random will be generated per thread, to offset philox counter in thc random
-    // // state
-    // // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    // int64_t counter_offset = params.b * params.h * 32;
-    // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
-    // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
-
-    // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
-    //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
-    // }
-
-    set_params_alibi(params, 
-        const_cast<std::optional<at::Tensor> &>(alibi_slopes_), 
+    set_params_alibi(params,
+        const_cast<std::optional<at::Tensor> &>(alibi_slopes_),
         batch_size, num_heads);
 
     if (seqlen_k > 0) {
@@ -621,8 +612,7 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
         const bool zero_tensors,
         bool is_causal,
         const double softcap,
-        const bool return_softmax,
-        c10::optional<at::Generator> gen_) {
+        const bool return_softmax) {
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x = cc_major == 8 && cc_minor >= 0;
@@ -660,6 +650,8 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     int num_heads = sizes[1];
     const int head_size_og = sizes[2];
     const int num_heads_k = k.size(1);
+
+    TORCH_CHECK(p_dropout == 0.0f, "Sparse attention does not support dropout for inference");
 
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
@@ -768,26 +760,8 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     // Keep references to these tensors to extend their lifetime
     at::Tensor softmax_lse_accum, out_accum;
 
-    // NOTE(woosuk): Commented out because they are not used in inference.
-    // number of times random will be generated per thread, to offset philox counter in thc random
-    // state
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    // int64_t counter_offset = params.b * params.h * 32;
-    // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
-    // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
-
-    // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
-    //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
-    // }
-
-    set_params_alibi(params, 
-        const_cast<std::optional<at::Tensor> &>(alibi_slopes_), 
+    set_params_alibi(params,
+        const_cast<std::optional<at::Tensor> &>(alibi_slopes_),
         batch_size, num_heads);
 
     if (max_seqlen_k > 0) {
@@ -950,7 +924,7 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
             gen_, at::cuda::detail::getDefaultCUDAGenerator());
         // See Note [Acquire lock when using random generators]
         std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
+        new (params.philox_args) at::PhiloxCudaState(gen->philox_cuda_state(counter_offset));
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -1190,7 +1164,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
             gen_, at::cuda::detail::getDefaultCUDAGenerator());
         // See Note [Acquire lock when using random generators]
         std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
+        new (params.philox_args) at::PhiloxCudaState(gen->philox_cuda_state(counter_offset));
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -1405,8 +1379,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     } else if( is_dropout ) {
         // See Note [Acquire lock when using random generators]
         std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        new (params.philox_args) at::PhiloxCudaState(gen->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
     }
@@ -1634,8 +1608,8 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     } else if( is_dropout ) {
         // See Note [Acquire lock when using random generators]
         std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        new (params.philox_args) at::PhiloxCudaState(gen->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
     }

--- a/csrc/flash_attn/flash_sparse_api.cpp
+++ b/csrc/flash_attn/flash_sparse_api.cpp
@@ -6,8 +6,6 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
-#include "philox_unpack.cuh"  // For at::cuda::philox::unpack
 
 #include <cutlass/numeric_types.h>
 
@@ -425,9 +423,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
         const double softmax_scale,
         bool is_causal,
         const double softcap,
-        const bool return_softmax,
-        const std::optional<at::Generator> gen_) {
-    
+        const bool return_softmax) {
+
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x = cc_major == 8 && cc_minor >= 0;
     bool is_sm90 = cc_major == 9 && cc_minor == 0;
@@ -461,6 +458,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
     TORCH_CHECK(batch_size > 0, "batch size must be postive");
     TORCH_CHECK(head_size_og <= 256, "FlashAttention forward only supports head dimension at most 256");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+
+    TORCH_CHECK(p_dropout == 0.0f, "Sparse attention does not support dropout for inference");
 
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
@@ -547,26 +546,8 @@ mha_fwd_sparse(at::Tensor &q,         // batch_size x seqlen_q x num_heads x hea
         params, batch_size, num_heads, head_size, seqlen_k, seqlen_q,
         head_size_rounded, p_dropout, /*num_splits*/ 1, get_num_sm(get_current_device()), opts);
 
-    // NOTE(woosuk): Commented out because they are not used in inference.
-    // // number of times random will be generated per thread, to offset philox counter in thc random
-    // // state
-    // // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    // int64_t counter_offset = params.b * params.h * 32;
-    // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
-    // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
-
-    // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
-    //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
-    // }
-
-    set_params_alibi(params, 
-        const_cast<std::optional<at::Tensor> &>(alibi_slopes_), 
+    set_params_alibi(params,
+        const_cast<std::optional<at::Tensor> &>(alibi_slopes_),
         batch_size, num_heads);
 
     if (seqlen_k > 0) {
@@ -607,8 +588,7 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
         const bool zero_tensors,
         bool is_causal,
         const double softcap,
-        const bool return_softmax,
-        c10::optional<at::Generator> gen_) {
+        const bool return_softmax) {
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x = cc_major == 8 && cc_minor >= 0;
@@ -646,6 +626,8 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     int num_heads = sizes[1];
     const int head_size_og = sizes[2];
     const int num_heads_k = k.size(1);
+
+    TORCH_CHECK(p_dropout == 0.0f, "Sparse attention does not support dropout for inference");
 
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
@@ -754,26 +736,8 @@ mha_varlen_fwd_sparse(at::Tensor &q,  // total_q x num_heads x head_size, total_
     // Keep references to these tensors to extend their lifetime
     at::Tensor softmax_lse_accum, out_accum;
 
-    // NOTE(woosuk): Commented out because they are not used in inference.
-    // number of times random will be generated per thread, to offset philox counter in thc random
-    // state
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    // int64_t counter_offset = params.b * params.h * 32;
-    // auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    // auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
-    // // Forward kernel will populate memory with the seed and offset.
-    // params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
-
-    // if (p_dropout > 0.0)  {
-    //     auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-    //         gen_, at::cuda::detail::getDefaultCUDAGenerator());
-    //     // See Note [Acquire lock when using random generators]
-    //     std::lock_guard<std::mutex> lock(gen->mutex_);
-    //     params.philox_args = gen->philox_cuda_state(counter_offset);
-    // }
-
-    set_params_alibi(params, 
-        const_cast<std::optional<at::Tensor> &>(alibi_slopes_), 
+    set_params_alibi(params,
+        const_cast<std::optional<at::Tensor> &>(alibi_slopes_),
         batch_size, num_heads);
 
     if (max_seqlen_k > 0) {

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -9,8 +9,6 @@
 #include <cuda.h>
 #include <vector>
 
-#include <ATen/cuda/CUDAGeneratorImpl.h> // For at::Generator and at::PhiloxCudaState
-
 namespace FLASH_NAMESPACE {
 constexpr int TOTAL_DIM = 0;
 constexpr int H_DIM = 1;
@@ -118,8 +116,12 @@ struct Flash_fwd_params : public Qkv_params {
     int window_size_left, window_size_right;
     float softcap;
 
-    // Random state.
-    at::PhiloxCudaState philox_args;
+    // Opaque storage for at::PhiloxCudaState (currently 24 bytes so we round up
+    // for cushion). Decouples this header (and the sparse inference path that 
+    // transitively includes it) from <ATen/cuda/CUDAGeneratorImpl.h>. Code for
+    // training in flash_api.cpp will write into it via placement-new and their
+    // respective kernels will read it via reinterpret_cast.
+    uint64_t philox_args[4];
 
     // Pointer to the RNG seed (idx 0) and offset (idx 1).
     uint64_t * rng_state;

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -66,7 +66,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     constexpr int kHeadDim = Kernel_traits::kHeadDim;
     constexpr int kNWarps = Kernel_traits::kNWarps;
 
-    auto seed_offset = at::cuda::philox::unpack(params.philox_args);
+    auto seed_offset = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
     FLASH_NAMESPACE::Dropout dropout(std::get<0>(seed_offset), std::get<1>(seed_offset), params.p_dropout_in_uint8_t,
                            bidb, bidh, tidx, params.h);
 

--- a/csrc/flash_attn/src/flash_fwd_sparse_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_sparse_kernel.h
@@ -10,7 +10,7 @@ namespace FLASH_NAMESPACE {
 
 using namespace cute;
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Return_softmax, typename Params>
+template<typename Kernel_traits, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, typename Params>
 inline __device__ void sparse_attn_1rowblock(const Params &params, const int bidb, const int bidh, const int m_block) {
 
     using Element = typename Kernel_traits::Element;
@@ -27,17 +27,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     constexpr int kBlockN = Kernel_traits::kBlockN;
     constexpr int kHeadDim = Kernel_traits::kHeadDim;
     constexpr int kNWarps = Kernel_traits::kNWarps;
-
-    auto seed_offset = at::cuda::philox::unpack(params.philox_args);
-    flash::Dropout dropout(std::get<0>(seed_offset), std::get<1>(seed_offset), params.p_dropout_in_uint8_t,
-                           bidb, bidh, tidx, params.h);
-
-    // Save seed and offset for backward, before any early exiting. Otherwise the 0-th thread block might
-    // exit early and no one saves the rng states.
-    if (Is_dropout && blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && tidx == 0) {
-        params.rng_state[0] = std::get<0>(seed_offset);
-        params.rng_state[1] = std::get<1>(seed_offset);
-    }
 
     const BlockInfo</*Varlen=*/!Is_even_MN> binfo(params, bidb);
     if (m_block * kBlockM >= binfo.actual_seqlen_q) return;
@@ -58,9 +47,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     // We iterate over the blocks in reverse order. This is because the last block is the only one
     // that needs masking when we read K and V from global memory. Moreover, iterating in reverse
     // might save us 1 register (we just need n_block instead of both n_block and n_block_max).
-
-    const index_t row_offset_p = ((bidb * params.h + bidh) * params.seqlen_q_rounded
-        + m_block * kBlockM) * params.seqlen_k_rounded + (n_block_max - 1) * kBlockN;
 
     Tensor mQ = make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(params.q_ptr)
                                           + binfo.q_offset(params.q_batch_stride, params.q_row_stride, bidb)),
@@ -93,10 +79,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     Tensor gVToken = make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(params.v_ptr) + row_offset_v_token),
         Shape<Int<kBlockN>, Int<kHeadDim>>{},
         make_stride(_0{}, _1{}));
-        
-    Tensor gP = make_tensor(make_gmem_ptr(reinterpret_cast<Element *>(params.p_ptr) + row_offset_p),
-                            Shape<Int<kBlockM>, Int<kBlockN>>{},
-                            make_stride(params.seqlen_k_rounded, _1{}));
 
     Tensor sQ = make_tensor(make_smem_ptr(reinterpret_cast<Element *>(smem_)),
                             typename Kernel_traits::SmemLayoutQ{});
@@ -131,8 +113,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     Tensor tSrQ  = thr_mma.partition_fragment_A(sQ);                           // (MMA,MMA_M,MMA_K)
     Tensor tSrK  = thr_mma.partition_fragment_B(sK);                           // (MMA,MMA_N,MMA_K)
     Tensor tOrVt  = thr_mma.partition_fragment_B(sVtNoSwizzle);                // (MMA, MMA_K,MMA_N)
-
-    Tensor tSgS  = thr_mma.partition_C(gP);
 
     Tensor acc_o = partition_fragment_C(tiled_mma, Shape<Int<kBlockM>, Int<kHeadDim>>{});  // MMA, MMA_M, MMA_K
 
@@ -346,20 +326,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
 
             // Convert acc_s from fp32 to fp16/bf16
             Tensor rP = flash::convert_type<Element>(acc_s);
-            int block_row_idx = m_block * (kBlockM / 16) + tidx / 32;
-            int block_col_idx = n_block * (kBlockN / 32);
-            if (Return_softmax) {
-                Tensor rP_drop = make_fragment_like(rP);
-                cute::copy(rP, rP_drop);
-                dropout.template apply_dropout</*encode_dropout_in_sign_bit=*/true>(
-                    rP_drop, block_row_idx, block_col_idx, kNWarps
-                );
-                cute::copy(rP_drop, tSgS);
-                tSgS.data() = tSgS.data() + (-kBlockN);
-            }
-            if (Is_dropout) {
-                dropout.apply_dropout(rP, block_row_idx, block_col_idx, kNWarps);
-            }
 
             // Reshape rP from (MMA=4, MMA_M, MMA_N) to ((4, 2), MMA_M, MMA_N / 2)
             // if using m16n8k16 or (4, MMA_M, MMA_N) if using m16n8k8.
@@ -405,20 +371,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
 
             // Convert acc_s from fp32 to fp16/bf16
             Tensor rP = flash::convert_type<Element>(acc_s);
-            int block_row_idx = m_block * (kBlockM / 16) + tidx / 32;
-            int block_col_idx = n_block * (kBlockN / 32);
-            if (Return_softmax) {
-                Tensor rP_drop = make_fragment_like(rP);
-                cute::copy(rP, rP_drop);
-                dropout.template apply_dropout</*encode_dropout_in_sign_bit=*/true>(
-                    rP_drop, block_row_idx, block_col_idx, kNWarps
-                );
-                cute::copy(rP_drop, tSgS);
-                tSgS.data() = tSgS.data() + (-kBlockN);
-            }
-            if (Is_dropout) {
-                dropout.apply_dropout(rP, block_row_idx, block_col_idx, kNWarps);
-            }
 
             // Reshape rP from (MMA=4, MMA_M, MMA_N) to ((4, 2), MMA_M, MMA_N / 2)
             // if using m16n8k16 or (4, MMA_M, MMA_N) if using m16n8k8.
@@ -428,7 +380,7 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
             // if (cute::thread0()) { print(scores); }
         }
     }
-     
+
     if (num_cols > 0) {
         auto* cols_ptr = params.column_index + ((bidb * params.h + bidh) * params.NUM_ROWS + m_block) * params.NNZ_V;
         // We don't need to clear the sK smem tiles since we'll mask out the scores anyway.
@@ -574,20 +526,6 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
 
             // Convert acc_s from fp32 to fp16/bf16
             Tensor rP = flash::convert_type<Element>(acc_s);
-            int block_row_idx = m_block * (kBlockM / 16) + tidx / 32;
-            int block_col_idx = n_block * (kBlockN / 32);
-            if (Return_softmax) {
-                Tensor rP_drop = make_fragment_like(rP);
-                cute::copy(rP, rP_drop);
-                dropout.template apply_dropout</*encode_dropout_in_sign_bit=*/true>(
-                    rP_drop, block_row_idx, block_col_idx, kNWarps
-                );
-                cute::copy(rP_drop, tSgS);
-                tSgS.data() = tSgS.data() + (-kBlockN);
-            }
-            if (Is_dropout) {
-                dropout.apply_dropout(rP, block_row_idx, block_col_idx, kNWarps);
-            }
 
             // Reshape rP from (MMA=4, MMA_M, MMA_N) to ((4, 2), MMA_M, MMA_N / 2)
             // if using m16n8k16 or (4, MMA_M, MMA_N) if using m16n8k8.
@@ -600,7 +538,7 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
 
     // Epilogue
 
-    Tensor lse = softmax.template normalize_softmax_lse<Is_dropout>(acc_o, params.scale_softmax, params.rp_dropout);
+    Tensor lse = softmax.template normalize_softmax_lse</*Is_dropout=*/false>(acc_o, params.scale_softmax, params.rp_dropout);
 
     // Convert acc_o from fp32 to fp16/bf16
     Tensor rO = flash::convert_type<Element>(acc_o);
@@ -663,7 +601,7 @@ inline __device__ void sparse_attn_1rowblock(const Params &params, const int bid
     );
 }
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Return_softmax, typename Params>
+template<typename Kernel_traits, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, typename Params>
 inline __device__ void compute_sparse_attn(const Params &params) {
     const int m_block = blockIdx.x;
     // The block index for the batch.
@@ -679,7 +617,7 @@ inline __device__ void compute_sparse_attn(const Params &params) {
     // the attention matrix. This way, as long as we have the batch, head, and the location of
     // the 16 x 32 block within the attention matrix, we can generate the exact same dropout pattern.
 
-    flash::sparse_attn_1rowblock<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap, Return_softmax>(params, bidb, bidh, m_block);
+    flash::sparse_attn_1rowblock<Kernel_traits, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap>(params, bidb, bidh, m_block);
 }
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_sparse_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_sparse_launch_template.h
@@ -11,16 +11,16 @@
 
 namespace FLASH_NAMESPACE {
 
-DEFINE_FLASH_FORWARD_KERNEL(flash_fwd_sparse_kernel, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Return_softmax) {
+DEFINE_FLASH_FORWARD_KERNEL(flash_fwd_sparse_kernel, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap) {
     #if defined(ARCH_SUPPORTS_FLASH)
         static_assert(!(Is_causal && Is_local)); // Enforce constraints
-        FLASH_NAMESPACE::compute_sparse_attn<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap, Return_softmax>(params);
+        FLASH_NAMESPACE::compute_sparse_attn<Kernel_traits, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap>(params);
     #else
         FLASH_UNSUPPORTED_ARCH
     #endif
 }
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal>
+template<typename Kernel_traits, bool Is_causal>
 void run_flash_sparse_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr size_t smem_size = Kernel_traits::kSmemSize;
     // printf("smem_size = %d\n", smem_size);
@@ -32,33 +32,21 @@ void run_flash_sparse_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     const int num_m_block = (params.seqlen_q + Kernel_traits::kBlockM - 1) / Kernel_traits::kBlockM;
     dim3 grid(num_m_block, params.b, params.h);
     const bool is_even_K = params.d == Kernel_traits::kHeadDim;
-    const bool return_softmax = params.p_ptr != nullptr;
     EVENK_SWITCH(is_even_K, IsEvenKConst, [&] {
-        BOOL_SWITCH(return_softmax, ReturnSoftmaxConst, [&] {
-            ALIBI_SWITCH(params.alibi_slopes_ptr != nullptr, Has_alibi, [&] {
-                SOFTCAP_SWITCH(params.softcap > 0.0, Is_softcap, [&] {
-                    constexpr bool IsEvenMNConst = false;
-                    constexpr bool Is_local = false;
-                    // Will only return softmax if dropout, to reduce compilation time.
-                    // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
-                    // If return_softmax, set IsEvenMNConst to false to reduce number of templates
-                    // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
-                    // If Is_local, set Is_causal to false
-                    auto kernel = &flash_fwd_sparse_kernel<Kernel_traits, Is_dropout && !Is_softcap, Is_causal, Is_local && !Is_causal, Has_alibi, IsEvenMNConst && IsEvenKConst && !Is_local && !ReturnSoftmaxConst && Kernel_traits::kHeadDim <= 128, IsEvenKConst, Is_softcap, ReturnSoftmaxConst && Is_dropout && !Is_softcap>;
-                    // auto kernel = &flash_fwd_kernel<Kernel_traits, false, Is_causal, false, false, true, true, false>;
-                    // printf("IsEvenMNConst = %d, IsEvenKConst = %d, Is_local = %d, Is_causal = %d, ReturnSoftmaxConst = %d, Is_dropout = %d\n", int(IsEvenMNConst), int(IsEvenKConst), int(Is_local), int(Is_causal), int(ReturnSoftmaxConst), int(Is_dropout));
-                    // auto kernel = &flash_fwd_kernel<Kernel_traits, false, Is_causal, false, true, true, false>;
-                    if (smem_size >= 48 * 1024) {
-                        C10_CUDA_CHECK(cudaFuncSetAttribute(
-                            kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-                    }
-                    // int ctas_per_sm;
-                    // cudaError status_ = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-                    //     &ctas_per_sm, kernel, Kernel_traits::kNThreads, smem_size);
-                    // printf("smem_size = %d, CTAs per SM = %d\n", int(smem_size), ctas_per_sm);
-                    kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(params);
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
-                });
+        ALIBI_SWITCH(params.alibi_slopes_ptr != nullptr, Has_alibi, [&] {
+            SOFTCAP_SWITCH(params.softcap > 0.0, Is_softcap, [&] {
+                constexpr bool IsEvenMNConst = false;
+                constexpr bool Is_local = false;
+                // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
+                // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
+                // If Is_local, set Is_causal to false
+                auto kernel = &flash_fwd_sparse_kernel<Kernel_traits, Is_causal, Is_local && !Is_causal, Has_alibi, IsEvenMNConst && IsEvenKConst && !Is_local && Kernel_traits::kHeadDim <= 128, IsEvenKConst, Is_softcap>;
+                if (smem_size >= 48 * 1024) {
+                    C10_CUDA_CHECK(cudaFuncSetAttribute(
+                        kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                }
+                kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(params);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
             });
         });
     });
@@ -67,65 +55,49 @@ void run_flash_sparse_fwd(Flash_fwd_params &params, cudaStream_t stream) {
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim32(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 32;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim64(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 64;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim96(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 96;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim128(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 128;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim160(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 160;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim192(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 192;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim224(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 224;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 template<typename T, bool Is_causal>
 void run_mha_fwd_sparse_hdim256(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 256;
-    DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-    });
+    run_flash_sparse_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_causal>(params, stream);
 }
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/philox_unpack.cuh
+++ b/csrc/flash_attn/src/philox_unpack.cuh
@@ -1,4 +1,5 @@
 // This is purely so that it works with torch 2.1. For torch 2.2+ we can include ATen/cuda/PhiloxUtils.cuh
 
 #pragma once
+#include <ATen/cuda/PhiloxCudaState.h>  // For at::PhiloxCudaState; UnpackRaw.cuh uses but does not include it.
 #include <ATen/cuda/detail/UnpackRaw.cuh>

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -106,7 +106,6 @@ def _sparse_attn_forward(
         causal,
         softcap,
         return_softmax,
-        None,
     )
     return out, softmax_lse
 
@@ -154,7 +153,6 @@ def _sparse_attn_varlen_forward(
         causal,
         softcap,
         return_softmax,
-        None,
     )
     return out, softmax_lse
 


### PR DESCRIPTION
We want to migrate sglang/sgl-kernel to ABI stable (https://github.com/sgl-project/sglang/issues/26598) and sgl-kernel only pulls in the flash_sparse_api.cpp (and some .cu files) from this fork.

PyTorch doesn't have stable ABI equivalents for Philox/at::Generator version 2.11 (desired target runtime version). These APIs are thankfully only used for dropout, which is commented out dead code in the file as inference doesn't use dropout.

This change does 2 things:
1. It deletes the commented out dead code completely, as well as now-dead references to Generator and Philox APIs in flash_sparse_api.cpp. We then recursively delete the now unreachable dropout code in the sparse launch template, which includes eliminating return_softmax (only enabled if dropout).
2. This one I have a question to the maintainers: for stable ABI migration, we would need to detangle flash_sparse_api.cpp from pulling in the unstable APIs (at::Generator or the PhiloxState from ATen/cuda/CUDAGeneratorImpl.h). Currently, those are transitively included from flash_sparse.h pulling in flash.h. **In order to minimize deviance from the original code, I've opted for swapping out the state with an opaque buffer.** Another option is creating an entirely different kernel arg struct for the sparse APIs, but that would induce more code changes across the kernel code, but could be a clearer alternative. Some important context is that flash_sparse_api.cpp is the only file fetched into sgl-kernel relating to FA2: https://github.com/sgl-project/sglang/blob/main/sgl-kernel/CMakeLists.txt#L313-L317 so I am suspecting very few people use this fork's flash_api.cpp anyway.

Test plan:
Locally using scaffolding in https://github.com/sgl-project/sglang/pull/26827 to pull in, build and test this change. 
- [x] built
- [x] `pytest --noconftest tests/test_flash_attention.py` all pass