### PR TITLE
[FA3] Validate varlen cu_seqlens on device before attention

### DIFF
--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -217,7 +217,14 @@ struct Flash_bwd_params : public Flash_fwd_params {
 
 template <int Arch, typename T, int kHeadDim, int kHeadDimV, bool Split, bool PagedKVNonTMA, bool Has_softcap, bool PackGQA>
 void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream);
-void prepare_varlen_num_blocks(Flash_fwd_params &params, cudaStream_t stream, bool packgqa, int blockM, int blockN, bool enable_pdl);
+void prepare_varlen_num_blocks(
+    Flash_fwd_params &params,
+    cudaStream_t stream,
+    bool packgqa,
+    int blockM,
+    int blockN,
+    bool enable_pdl,
+    bool validate_cu_seqlens);
 template <int Arch, typename T, int kHeadDim, bool Has_softcap>
 void run_mha_bwd_(Flash_bwd_params &params, cudaStream_t stream);
 template <typename T, typename Tpartial, int kBlockK>

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -655,7 +655,14 @@ mha_fwd_get_scheduler_metadata(
         int const kBlockM = params.arch >= 90 ? std::get<0>(kBlockMN_kernel_args_sm90) : std::get<0>(kBlockMN_kernel_args_sm8x);
         int const kBlockN = params.arch >= 90 ? std::get<1>(kBlockMN_kernel_args_sm90) : std::get<1>(kBlockMN_kernel_args_sm8x);
         auto stream = at::cuda::getCurrentCUDAStream().stream();
-        prepare_varlen_num_blocks(params, stream, params.pack_gqa, kBlockM, kBlockN, false /*enable_pdl*/);
+        prepare_varlen_num_blocks(
+            params,
+            stream,
+            params.pack_gqa,
+            kBlockM,
+            kBlockN,
+            false /*enable_pdl*/,
+            false /*validate_cu_seqlens*/);
         CHECK_CUDA_KERNEL_LAUNCH();
     }
     return tile_count_semaphore;

--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -724,7 +724,14 @@ mha_fwd_get_scheduler_metadata(
         void* stream_ptr = nullptr;
         TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
         cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
-        prepare_varlen_num_blocks(params, stream, params.pack_gqa, kBlockM, kBlockN, false /*enable_pdl*/);
+        prepare_varlen_num_blocks(
+            params,
+            stream,
+            params.pack_gqa,
+            kBlockM,
+            kBlockN,
+            false /*enable_pdl*/,
+            false /*validate_cu_seqlens*/);
         CHECK_CUDA_KERNEL_LAUNCH();
     }
     return tile_count_semaphore;

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -161,7 +161,14 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     };
 
     if (Varlen && !params.skip_scheduler_metadata_computation) {
-        prepare_varlen_num_blocks(params, stream, PackGQA, kBlockM, kBlockN, Arch >= 90 && params.prepare_varlen_pdl /*enable_pdl*/);
+        prepare_varlen_num_blocks(
+            params,
+            stream,
+            PackGQA,
+            kBlockM,
+            kBlockN,
+            Arch >= 90 && params.prepare_varlen_pdl /*enable_pdl*/,
+            true /*validate_cu_seqlens*/);
         CHECK_CUDA_KERNEL_LAUNCH();
     }
 

--- a/hopper/flash_prepare_scheduler.cu
+++ b/hopper/flash_prepare_scheduler.cu
@@ -3,6 +3,7 @@
  ******************************************************************************/
 
 #include <cub/cub.cuh>
+#include <c10/macros/Macros.h>
 #include "cutlass/fast_math.h"
 #include "cutlass/barrier.h"
 #include "cutlass/arch/barrier.h"
@@ -55,7 +56,11 @@ __global__ void prepare_varlen_num_blocks_kernel(
         bool enable_pdl,
         bool is_causal,
         bool packgqa,
-        int max_kvblocks_in_l2) {
+        int max_kvblocks_in_l2,
+        int total_q,
+        int total_k,
+        int total_k_new,
+        bool validate_cu_seqlens) {
 
     static constexpr int kNumBatchPerWarp = cutlass::NumThreadsPerWarp - 1;
     static constexpr int kSmemSize = 1;
@@ -69,7 +74,7 @@ __global__ void prepare_varlen_num_blocks_kernel(
     // Allocate shared memory for BlockMergeSort operations
     __shared__ typename BlockMergeSort::TempStorage temp_storage;
 
-    if (enable_pdl) { cutlass::arch::launch_dependent_grids(); }
+    if (enable_pdl && !validate_cu_seqlens) { cutlass::arch::launch_dependent_grids(); }
 
     if (threadIdx.x < kSmemSize) { total_blocks_smem[threadIdx.x] = 0; }
     __syncthreads();
@@ -78,14 +83,45 @@ __global__ void prepare_varlen_num_blocks_kernel(
 
     int lane = threadIdx.x % cutlass::NumThreadsPerWarp;
 
+    if (validate_cu_seqlens && blockIdx.x == 0 && threadIdx.x == 0) {
+        if (cu_seqlens_q) {
+            CUDA_KERNEL_ASSERT_MSG(cu_seqlens_q[0] == 0, "cu_seqlens_q must start at 0");
+            CUDA_KERNEL_ASSERT_MSG(
+                cu_seqlens_q[num_batch] == total_q,
+                "cu_seqlens_q must end at the total number of query tokens");
+        }
+        if (cu_seqlens_k) {
+            CUDA_KERNEL_ASSERT_MSG(cu_seqlens_k[0] == 0, "cu_seqlens_k must start at 0");
+            CUDA_KERNEL_ASSERT_MSG(
+                cu_seqlens_k[num_batch] == total_k,
+                "cu_seqlens_k must end at the total number of key tokens");
+        }
+        if (cu_seqlens_k_new) {
+            CUDA_KERNEL_ASSERT_MSG(cu_seqlens_k_new[0] == 0, "cu_seqlens_k_new must start at 0");
+            CUDA_KERNEL_ASSERT_MSG(
+                cu_seqlens_k_new[num_batch] == total_k_new,
+                "cu_seqlens_k_new must end at the total number of new key tokens");
+        }
+    }
+
     auto get_num_m_blocks = [&](int batch_idx) {
+        int cu_seqlen = 0;
+        if (cu_seqlens_q) {
+            int cur_cu_seqlen = batch_idx <= num_batch ? cu_seqlens_q[batch_idx] : 0;
+            int next_cu_seqlen = __shfl_down_sync(0xffffffff, cur_cu_seqlen, 1);
+            cu_seqlen = next_cu_seqlen - cur_cu_seqlen;
+            if (validate_cu_seqlens && batch_idx < num_batch && lane < kNumBatchPerWarp) {
+                CUDA_KERNEL_ASSERT_MSG(cu_seqlen >= 0, "cu_seqlens_q must be non-decreasing");
+                CUDA_KERNEL_ASSERT_MSG(
+                    cu_seqlen <= seqlen_q_static,
+                    "cu_seqlens_q contains a sequence longer than max_seqlen_q");
+            }
+        }
         int seqlen;
         if (seqused_q) {
             seqlen = batch_idx < num_batch ? seqused_q[batch_idx] : 0;
         } else if (cu_seqlens_q) {
-            int cur_cu_seqlen = batch_idx <= num_batch ? cu_seqlens_q[batch_idx] : 0;
-            int next_cu_seqlen = __shfl_down_sync(0xffffffff, cur_cu_seqlen, 1);
-            seqlen = next_cu_seqlen - cur_cu_seqlen;
+            seqlen = cu_seqlen;
         } else {
             seqlen = seqlen_q_static;
         }
@@ -96,13 +132,23 @@ __global__ void prepare_varlen_num_blocks_kernel(
 
     auto get_num_n_blocks = [&](int batch_idx) {
         int leftpad_k = batch_idx < num_batch && leftpad_k_ptr != nullptr ? leftpad_k_ptr[batch_idx] : 0;
+        int cu_seqlen = 0;
+        if (cu_seqlens_k) {
+            int cur_cu_seqlen = batch_idx <= num_batch ? cu_seqlens_k[batch_idx] : 0;
+            int next_cu_seqlen = __shfl_down_sync(0xffffffff, cur_cu_seqlen, 1);
+            cu_seqlen = next_cu_seqlen - cur_cu_seqlen;
+            if (validate_cu_seqlens && batch_idx < num_batch && lane < kNumBatchPerWarp) {
+                CUDA_KERNEL_ASSERT_MSG(cu_seqlen >= 0, "cu_seqlens_k must be non-decreasing");
+                CUDA_KERNEL_ASSERT_MSG(
+                    cu_seqlen <= seqlen_k_static,
+                    "cu_seqlens_k contains a sequence longer than max_seqlen_k");
+            }
+        }
         int seqlen;
         if (seqused_k) {
             seqlen = batch_idx < num_batch ? seqused_k[batch_idx] : 0;
         } else if (cu_seqlens_k) {
-            int cur_cu_seqlen = batch_idx <= num_batch ? cu_seqlens_k[batch_idx] : 0;
-            int next_cu_seqlen = __shfl_down_sync(0xffffffff, cur_cu_seqlen, 1);
-            seqlen = next_cu_seqlen - cur_cu_seqlen;
+            seqlen = cu_seqlen;
         } else {
             seqlen = seqlen_k_static;
         }
@@ -111,6 +157,12 @@ __global__ void prepare_varlen_num_blocks_kernel(
             int cur_cu_seqlen_new = batch_idx <= num_batch ? cu_seqlens_k_new[batch_idx] : 0;
             int next_cu_seqlen_new = __shfl_down_sync(0xffffffff, cur_cu_seqlen_new, 1);
             seqlen_new = next_cu_seqlen_new - cur_cu_seqlen_new;
+            if (validate_cu_seqlens && batch_idx < num_batch && lane < kNumBatchPerWarp) {
+                CUDA_KERNEL_ASSERT_MSG(seqlen_new >= 0, "cu_seqlens_k_new must be non-decreasing");
+                CUDA_KERNEL_ASSERT_MSG(
+                    seqlen_new <= seqlen_k_new_static,
+                    "cu_seqlens_k_new contains a sequence longer than max_seqlen_k_new");
+            }
         } else {
             seqlen_new = seqlen_k_new_static;
         }
@@ -126,6 +178,10 @@ __global__ void prepare_varlen_num_blocks_kernel(
     int batch_idx = lane + bidb_start;
     int num_m_blocks = get_num_m_blocks(batch_idx);
     int num_n_blocks = get_num_n_blocks(batch_idx);
+
+    // Delay the dependent attention grid until all cu_seqlens validation has
+    // executed. PDL is only enabled when this preparation uses a single CTA.
+    if (enable_pdl && validate_cu_seqlens) { cutlass::arch::launch_dependent_grids(); }
 
     auto get_nheads_in_l2 = [&](int n_blocks) {
         int nheads_in_l2 = n_blocks * 16 <= max_kvblocks_in_l2 ? 16
@@ -217,7 +273,7 @@ __global__ void prepare_varlen_num_blocks_kernel(
 } // flash
 
 void prepare_varlen_num_blocks(Flash_fwd_params &params, cudaStream_t stream, bool packgqa,
-                               int blockM, int blockN, bool enable_pdl) {
+                               int blockM, int blockN, bool enable_pdl, bool validate_cu_seqlens) {
     int qhead_per_khead = cutlass::ceil_div(params.h, params.h_k);
     int num_warps = cutlass::ceil_div(params.b, 31); // warp switch will cap this at 32
     int num_ctas = cutlass::ceil_div(params.b, 31 * 32);
@@ -244,7 +300,11 @@ void prepare_varlen_num_blocks(Flash_fwd_params &params, cudaStream_t stream, bo
                 enable_pdl,
                 params.is_causal,
                 packgqa,
-                max_kvblocks_in_l2);
+                max_kvblocks_in_l2,
+                params.total_q,
+                params.total_k,
+                params.total_knew,
+                validate_cu_seqlens);
         });
     });
 }

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -1,6 +1,9 @@
 import os
 import math
 import itertools
+import subprocess
+import sys
+import textwrap
 
 import pytest
 import torch
@@ -1261,3 +1264,59 @@ def test_flash3_bw_compatibility() -> None:
         "int attention_chunk=0, bool has_softcap=False, int num_splits=0, bool? pack_gqa=None, "
         "int sm_margin=0) -> Tensor"
     ))
+
+
+@pytest.mark.parametrize(
+    ("invalid_cu_seqlens", "expected_message"),
+    [
+        ("q", "cu_seqlens_q must end at the total number of query tokens"),
+        ("k", "cu_seqlens_k must end at the total number of key tokens"),
+    ],
+)
+def test_flash_attn_varlen_rejects_mismatched_cu_seqlens(
+    invalid_cu_seqlens, expected_message
+):
+    # A device-side assertion poisons its CUDA context. Run each failure in a
+    # child process so the rest of the test suite can continue using the GPU.
+    child = textwrap.dedent(
+        f"""
+        import torch
+        from flash_attn_interface import flash_attn_varlen_func
+
+        total_tokens = 8
+        q = torch.randn(
+            total_tokens, 1, 64, device="cuda", dtype=torch.bfloat16
+        )
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        valid = torch.tensor(
+            [0, total_tokens], device="cuda", dtype=torch.int32
+        )
+        invalid = torch.tensor(
+            [0, total_tokens - 1], device="cuda", dtype=torch.int32
+        )
+        cu_seqlens_q = invalid if {invalid_cu_seqlens!r} == "q" else valid
+        cu_seqlens_k = invalid if {invalid_cu_seqlens!r} == "k" else valid
+
+        flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            total_tokens,
+            total_tokens,
+        )
+        torch.cuda.synchronize()
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=os.path.dirname(__file__),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -1266,34 +1266,63 @@ def test_flash3_bw_compatibility() -> None:
     ))
 
 
+def _run_cuda_assert_subprocess(child, expected_message):
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(child)],
+        cwd=os.path.dirname(__file__),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode != 0
+    assert expected_message in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("invalid_cu_seqlens", ["q", "k"])
 @pytest.mark.parametrize(
-    ("invalid_cu_seqlens", "expected_message"),
+    ("invalid_offsets", "failure"),
     [
-        ("q", "cu_seqlens_q must end at the total number of query tokens"),
-        ("k", "cu_seqlens_k must end at the total number of key tokens"),
+        ([1, 2, 5, 8], "start"),
+        ([0, 2, 5, 7], "end"),
+        ([0, 5, 4, 8], "decreasing"),
+        ([0, 2, 8, 8], "max_seqlen"),
     ],
 )
 def test_flash_attn_varlen_rejects_mismatched_cu_seqlens(
-    invalid_cu_seqlens, expected_message
+    invalid_cu_seqlens, invalid_offsets, failure
 ):
     # A device-side assertion poisons its CUDA context. Run each failure in a
     # child process so the rest of the test suite can continue using the GPU.
-    child = textwrap.dedent(
-        f"""
+    prefix = f"cu_seqlens_{invalid_cu_seqlens}"
+    expected_message = {
+        "start": f"{prefix} must start at 0",
+        "end": (
+            f"{prefix} must end at the total number of "
+            f"{'query' if invalid_cu_seqlens == 'q' else 'key'} tokens"
+        ),
+        "decreasing": f"{prefix} must be non-decreasing",
+        "max_seqlen": (
+            f"{prefix} contains a sequence longer than "
+            f"max_seqlen_{invalid_cu_seqlens}"
+        ),
+    }[failure]
+    child = f"""
         import torch
         from flash_attn_interface import flash_attn_varlen_func
 
         total_tokens = 8
+        max_seqlen = 5
         q = torch.randn(
             total_tokens, 1, 64, device="cuda", dtype=torch.bfloat16
         )
         k = torch.randn_like(q)
         v = torch.randn_like(q)
         valid = torch.tensor(
-            [0, total_tokens], device="cuda", dtype=torch.int32
+            [0, 2, 5, total_tokens], device="cuda", dtype=torch.int32
         )
         invalid = torch.tensor(
-            [0, total_tokens - 1], device="cuda", dtype=torch.int32
+            {invalid_offsets!r}, device="cuda", dtype=torch.int32
         )
         cu_seqlens_q = invalid if {invalid_cu_seqlens!r} == "q" else valid
         cu_seqlens_k = invalid if {invalid_cu_seqlens!r} == "k" else valid
@@ -1304,19 +1333,52 @@ def test_flash_attn_varlen_rejects_mismatched_cu_seqlens(
             v,
             cu_seqlens_q,
             cu_seqlens_k,
-            total_tokens,
-            total_tokens,
+            max_seqlen,
+            max_seqlen,
         )
         torch.cuda.synchronize()
         """
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", child],
-        cwd=os.path.dirname(__file__),
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    _run_cuda_assert_subprocess(child, expected_message)
 
-    assert result.returncode != 0
-    assert expected_message in result.stderr
+
+def test_flash_attn_varlen_validates_cu_seqlens_on_cuda_graph_replay():
+    child = """
+        import torch
+        from flash_attn_interface import flash_attn_varlen_func
+
+        total_tokens = 8
+        max_seqlen = 5
+        q = torch.randn(
+            total_tokens, 1, 64, device="cuda", dtype=torch.bfloat16
+        )
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        cu_seqlens_q = torch.tensor(
+            [0, 2, 5, total_tokens], device="cuda", dtype=torch.int32
+        )
+        cu_seqlens_k = cu_seqlens_q.clone()
+
+        def run_attention():
+            return flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen,
+                max_seqlen,
+            )
+
+        run_attention()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_out = run_attention()
+
+        cu_seqlens_q[-1] = total_tokens - 1
+        graph.replay()
+        torch.cuda.synchronize()
+        """
+    _run_cuda_assert_subprocess(
+        child, "cu_seqlens_q must end at the total number of query tokens"
+    )


### PR DESCRIPTION
## Summary

- Validate FA3 varlen cu_seqlens inside the existing scheduler-preparation CUDA kernel.
- Require each array to start at zero, end at the matching packed-token count, remain non-decreasing, and respect max_seqlen.
- Delay the PDL dependent attention launch until validation executes.
- Add isolated subprocess regression tests for malformed Q/K metadata and CUDA graph replay.

## Motivation

A packed Q/K/V tensor can contain more rows than its cu_seqlens metadata covers, for example after CUDA graph bucket padding. FA3 currently accepts that mismatch and can corrupt the boundary output instead of rejecting the malformed input.

The check runs on device in the first existing varlen CUDA kernel. It adds no CPU-GPU synchronization and no extra kernel launch. Invalid metadata triggers a device assertion rather than allowing silent numerical corruption.

## Test coverage

The malformed-metadata suite covers both Q and K for:

- nonzero initial offset
- terminal offset not matching packed-token count
- decreasing offsets
- a sequence exceeding max_seqlen

A ninth test captures a valid forward in a CUDA graph, mutates the captured Q metadata to an invalid terminal offset, and verifies replay executes the device-side guard. Each expected assertion runs in a child process because a device assertion poisons its CUDA context.

## Testing

Local static checks:

- `python3 -m py_compile hopper/test_flash_attn.py`
- `git diff --check`

Hopper GPU validation:

- NVIDIA H200, SM90
- CUDA 13.0
- PyTorch 2.11.0.6+cu130
- Minimal FA3 BF16/varlen/head-dim-64 build succeeded with `-DNDEBUG`
- `pytest -q -s test_flash_attn.py -k "rejects_mismatched_cu_seqlens or validates_cu_seqlens_on_cuda_graph_replay" --tb=short`
- Result: 9 passed, 98751 deselected in 31.77s

Performance comparison against the exact parent commit (`fc8cbad6`), using identical builds on the same idle H200 GPU:

| Shape | Batch | Real tokens | Bucket-tail padding | Flattened tokens | CUDA graph baseline | CUDA graph guard | Delta | Eager delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Tiny | 1 | 8 | 0 | 8 | 10.236 us | 10.770 us | +0.535 us (+5.22%) | +0.989 us (+1.50%) |
| Incident-like | 4 | 112 | 0 | 112 | 10.310 us | 10.806 us | +0.497 us (+4.82%) | +2.024 us (+3.08%) |
| All short | 32 | 1,600 | 0 | 1,600 | 11.444 us | 11.907 us | +0.463 us (+4.04%) | +1.423 us (+2.16%) |
| Production seed-42 mix | 33 | 32,767 | 1 | 32,768 | 64.386 us | 64.745 us | +0.359 us (+0.56%) | +1.725 us (+2.51%) |
| Two long requests | 5 | 32,767 | 1 | 32,768 | 362.749 us | 364.134 us | +1.386 us (+0.38%) | +0.451 us (+0.12%) |

For the two 32K cases, the padding is represented as an explicit one-token dummy sequence so valid `cu_seqlens` still terminate at the flattened Q/K row count. These are GPU-active latencies measured with CUDA events, not end-to-end server latency. Each cell is the median of five run medians; each run used 11 timing groups after 20 warmups. Runs were interleaved symmetrically between baseline and guard.

## Current scope

This validates normal FA3 varlen forwards where scheduler metadata is prepared during the forward call. A caller supplying precomputed scheduler metadata bypasses the preparation kernel and therefore this validation.
