### PR TITLE
Support head dim 512 forward (SM80/SM90)

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -244,9 +244,10 @@ void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream, bool force_split
     FP16_SWITCH(!params.is_bf16, [&] {
         HEADDIM_SWITCH(params.d, [&] {
             BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-                if (params.num_splits <= 1 && !force_split_kernel) {  // If we don't set it num_splits == 0
+                if (params.num_splits <= 1 && !force_split_kernel && kHeadDim < 512) {  // If we don't set it num_splits == 0
                     run_mha_fwd_<elem_type, kHeadDim, Is_causal>(params, stream);
                 } else {
+                    // headdim 512 only has a split-KV (decode) kernel; non-split smem doesn't fit.
                     run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim, Is_causal>(params, stream);
                 }
             });
@@ -302,7 +303,7 @@ std::tuple<at::Tensor, at::Tensor> set_params_splitkv(Flash_fwd_params &params, 
     const int num_splits, const int num_sm, struct c10::TensorOptions opts) {
 
     // This needs to match with run_mha_fwd_splitkv_dispatch
-    const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
+    const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : (head_size <= 256 ? 64 : 32));
     const int num_n_blocks = (max_seqlen_k + block_n - 1) / block_n;
     // Technically kBlockM = 64 only for the splitKV kernels, not the standard kernel.
     // In any case we don't expect seqlen_q to be larger than 64 for inference.
@@ -390,7 +391,7 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(head_size <= 512, "FlashAttention forward only supports head dimension at most 512");
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -602,7 +603,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     const int total_q = q.sizes()[0];
 
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(head_size <= 512, "FlashAttention forward only supports head dimension at most 512");
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -761,7 +762,12 @@ void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     FP16_SWITCH(!params.is_bf16, [&] {
         HEADDIM_SWITCH(params.d, [&] {
             BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-                run_mha_bwd_<elem_type, kHeadDim, Is_causal>(params, stream);
+                // headdim 512 has no backward kernel (fwd split-KV / decode only).
+                if constexpr (kHeadDim <= 256) {
+                    run_mha_bwd_<elem_type, kHeadDim, Is_causal>(params, stream);
+                } else {
+                    TORCH_CHECK(false, "FlashAttention backward does not support head dimension > 256");
+                }
             });
         });
     });
@@ -1269,7 +1275,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
     const int num_heads_k = kcache.size(2);
     const int batch_size_c = !paged_KV ? kcache.size(0) : batch_size;
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    TORCH_CHECK(head_size_og <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(head_size_og <= 512, "FlashAttention forward only supports head dimension at most 512");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
     // causal=true is the same as causal=false in this case

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -98,7 +98,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     });
 }
 
-template<typename Kernel_traits, bool Is_causal>
+template<typename Kernel_traits, typename Combine_traits, bool Is_causal>
 void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     static_assert(!Kernel_traits::Is_Q_in_regs, "SplitKV implementation does not support Is_Q_in_regs");
     static_assert(!Kernel_traits::Share_Q_K_smem, "SplitKV implementation does not support Share_Q_K_smem");
@@ -134,27 +134,26 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
         });
     });
     if (params.num_splits > 1) {
-        // We want kBlockM to be as small as possible for more parallelism.
-        // With 128 threads we can load 512 elements at a time, so if headdim is divisible by 128, kBlockM = 4.
-        // If headdim is divisible by 64, then we set kBlockM = 8, etc.
-        constexpr static int kBlockM = Kernel_traits::kHeadDim % 128 == 0 ? 4 : (Kernel_traits::kHeadDim % 64 == 0 ? 8 : 16);
+        constexpr static int kBlockM = Combine_traits::kHeadDim % 128 == 0 ? 4 : (Combine_traits::kHeadDim % 64 == 0 ? 8 : 16);
         dim3 grid_combine((params.b * params.h * params.seqlen_q + kBlockM - 1) / kBlockM);
         EVENK_SWITCH(is_even_K, IsEvenKConst, [&] {
+            auto combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 1, IsEvenKConst>;
             if (params.num_splits <= 2) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 1, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 1, IsEvenKConst>;
             } else if (params.num_splits <= 4) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 2, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 2, IsEvenKConst>;
             } else if (params.num_splits <= 8) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 3, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 3, IsEvenKConst>;
             } else if (params.num_splits <= 16) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 4, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 4, IsEvenKConst>;
             } else if (params.num_splits <= 32) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 5, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 5, IsEvenKConst>;
             } else if (params.num_splits <= 64) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 6, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 6, IsEvenKConst>;
             } else if (params.num_splits <= 128) {
-                flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 7, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
+                combine_kernel = &flash_fwd_splitkv_combine_kernel<Combine_traits, kBlockM, 7, IsEvenKConst>;
             }
+            combine_kernel<<<grid_combine, Combine_traits::kNThreads, 0, stream>>>(params);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
         });
     }
@@ -162,18 +161,27 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
 
 template<typename T, int Headdim, bool Is_causal>
 void run_mha_fwd_splitkv_dispatch(Flash_fwd_params &params, cudaStream_t stream) {
-    constexpr static int kBlockM = 64;
+    constexpr static int kBlockM = Headdim > 256 ? 16 : 64;
+    constexpr static int kNWarps = kBlockM / 16;
     // TD [2023-08-28]: nvcc segfaults for headdim 96 with block size 64 x 256,
     // and for headdim 192 with block size 64 x 128.
-    constexpr static int kBlockN = Headdim <= 64 ? 256 : (Headdim <= 128 ? 128 : 64);
-    // if user specifies num_splits=1, we assume they want bitwise identical
-    // numerics across the split KV and standard kernels so we align kBLockN to
-    // match
-    if (params.num_splits == 1) {
-        constexpr static int kBlockN_standard = Headdim <= 64 ? 128 : 64;
-        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, 4, false, false, T>, Is_causal>(params, stream);
+    // headdim 512 uses kBlockN=32 to keep dynamic smem within the per-block limit.
+    constexpr static int kBlockN = Headdim <= 64 ? 256 : (Headdim <= 128 ? 128 : (Headdim <= 256 ? 64 : 32));
+    // The combine kernel always uses kBlockM=64 / 4 warps, independent of the attention tile.
+    using Combine_traits = Flash_fwd_kernel_traits<Headdim, 64, kBlockN, 4, false, false, T>;
+    if constexpr (Headdim <= 256) {
+        // if user specifies num_splits=1, we assume they want bitwise identical
+        // numerics across the split KV and standard kernels so we align kBLockN to
+        // match
+        if (params.num_splits == 1) {
+            constexpr static int kBlockN_standard = Headdim <= 64 ? 128 : 64;
+            run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, kNWarps, false, false, T>, Combine_traits, Is_causal>(params, stream);
+        } else {
+            run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, kNWarps, false, false, T>, Combine_traits, Is_causal>(params, stream);
+        }
     } else {
-        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, 4, false, false, T>, Is_causal>(params, stream);
+        // headdim 512 has no standard (non-split) kernel to align kBlockN against.
+        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, kNWarps, false, false, T>, Combine_traits, Is_causal>(params, stream);
     }
 }
 

--- a/csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 512, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 512, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 512, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 512, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/generate_kernels.py
+++ b/csrc/flash_attn/src/generate_kernels.py
@@ -11,6 +11,8 @@ DTYPE_MAP = {
 
 SM = [80]  # Sm80 kernels support up to
 HEAD_DIMENSIONS = [32, 64, 96, 128, 192, 256]
+# headdim 512 only has a split-KV (decode) kernel; prefill/bwd smem doesn't fit.
+SPLIT_ONLY_HEAD_DIMENSIONS = [512]
 IS_CAUSAL = ["false", "true"]
 NAMESPACE_INCLUDE = '#include "namespace_config.h"\n'
 
@@ -77,6 +79,8 @@ def get_all_kernels() -> List[Kernel]:
     for direction in ["fwd", "fwd_split", "bwd"]:
         for dtype, head_dim, is_causal, sm in itertools.product(DTYPE_MAP.keys(), HEAD_DIMENSIONS, IS_CAUSAL, SM):
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, is_causal=is_causal, direction=direction)
+    for dtype, head_dim, is_causal, sm in itertools.product(DTYPE_MAP.keys(), SPLIT_ONLY_HEAD_DIMENSIONS, IS_CAUSAL, SM):
+        yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, is_causal=is_causal, direction="fwd_split")
 
 def write_kernel(kernel: Kernel, autogen_dir: Path) -> None:
     prelude = """// Copyright (c) 2024, Tri Dao.

--- a/csrc/flash_attn/src/kernel_traits.h
+++ b/csrc/flash_attn/src/kernel_traits.h
@@ -68,7 +68,7 @@ struct Flash_fwd_kernel_traits : public Base {
     static constexpr int kHeadDim = kHeadDim_;
     static_assert(kHeadDim % 32 == 0);
     static constexpr int kBlockKSmem = kHeadDim % 64 == 0 ? 64 : 32;
-    static constexpr int kBlockKGmem = kHeadDim % 128 == 0 ? 128 : (kHeadDim % 64 == 0 ? 64 : 32);
+    static constexpr int kBlockKGmem = kHeadDim == 512 ? 32 : (kHeadDim % 128 == 0 ? 128 : (kHeadDim % 64 == 0 ? 64 : 32));
     static constexpr int kSwizzle = kBlockKSmem == 32 ? 2 : 3;
 
     using TiledMma = TiledMMA<
@@ -136,13 +136,15 @@ struct Flash_fwd_kernel_traits : public Base {
                         GmemLayoutAtom{},
                         Layout<Shape<_1, _8>>{}));  // Val layout, 8 vals per store
 
+    // Derived from kNThreads so that configs with fewer than 4 warps still cover every row.
     using GmemLayoutAtomOaccum = std::conditional_t<
         kBlockKSmem == 32,
-        Layout<Shape <_16, _8>,  // Thread layout, 8 threads per row
+        Layout<Shape <Int<kNThreads / 8>, _8>,  // Thread layout, 8 threads per row
                Stride< _8, _1>>,
-        Layout<Shape <_8, _16>,  // Thread layout, 16 threads per row
+        Layout<Shape <Int<kNThreads / 16>, _16>,  // Thread layout, 16 threads per row
                Stride< _16, _1>>
     >;
+    static_assert(kNThreads % 16 == 0, "kNThreads must be a multiple of 16 for GmemLayoutAtomOaccum");
     using GmemTiledCopyOaccum = decltype(
         make_tiled_copy(Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementAccum>{},
                         GmemLayoutAtomOaccum{},

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -107,5 +107,8 @@
     } else if (HEADDIM <= 256) {           \
       constexpr static int kHeadDim = 256; \
       return __VA_ARGS__();                \
+    } else if (HEADDIM <= 512) {           \
+      constexpr static int kHeadDim = 512; \
+      return __VA_ARGS__();                \
     }                                      \
   }()

--- a/docs/hdim512_bench.md
+++ b/docs/hdim512_bench.md
@@ -1,0 +1,33 @@
+# Head dim 512 decode benchmark (SM90)
+
+## Setup
+
+- GPU: H200 (sm90a), CUDA 13.0 (nvcc V13.0.88), torch 2.11.0+cu130
+- Shape: `b=1`, `sq=1` (decode), `hq=8 / hkv=1` (GQA), `hd_qk = hd_v = 512`, bf16, causal
+- FA3 numbers produced by:
+
+```bash
+python tests/hopper/bench_fa2_fa3_hd512.py --ns 0 --iters 100 --graph 1 \
+  --cases 1x1,1x64,1x512,1x2048,1x4096,1x8192,1x16384,1x32768
+```
+
+- `sglang-triton` and `ffpa-*` columns come from external implementations benchmarked under the same shapes.
+
+## Latency (ms, lower is better)
+
+| cache | sglang-triton | ffpa-cute | ffpa-triton | ffpa-sm80 | FA2-16x32 | FA2-32x32 | FA2-32x16 | FA3 | FA3 vs sglang-triton |
+|------:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 0.0070 | 0.014 | 0.042 | 0.023 | 0.0064 | 0.0060 | 0.0053 | 0.0095 | 0.74x |
+| 64 | 0.0072 | 0.014 | 0.046 | 0.023 | 0.0106 | 0.0100 | 0.0098 | 0.0096 | 0.75x |
+| 512 | 0.0124 | 0.014 | 0.011 | 0.024 | 0.0136 | 0.0132 | 0.0159 | 0.0138 | 0.90x |
+| 2048 | 0.0441 | 0.019 | 0.017 | 0.049 | 0.0234 | 0.0232 | 0.0339 | 0.0146 | 3.02x |
+| 4096 | 0.0850 | 0.026 | 0.029 | 0.076 | 0.0350 | 0.0348 | 0.0367 | 0.0166 | 5.12x |
+| 8192 | 0.1680 | 0.040 | 0.052 | 0.131 | 0.0393 | 0.0399 | 0.0416 | 0.0190 | 8.84x |
+| 16384 | 0.3267 | 0.069 | 0.099 | 0.241 | 0.0482 | 0.0508 | 0.0518 | 0.0234 | 13.96x |
+| 32768 | 0.6513 | 0.126 | 0.190 | 0.460 | 0.0667 | 0.0712 | 0.0753 | 0.0366 | 17.80x |
+
+## Notes
+
+- For short caches (<= 512) FA3 is at parity or slightly behind, where launch/setup overhead dominates.
+- FA3 scales best with cache length: 3.0x at 2K and 17.8x at 32K over sglang-triton, and it is the fastest of all measured implementations from cache=2048 onward.
+- Correctness check: `python tests/hopper/verify_fa3_causal_decode_prefill.py` must end with `ALL PASS`.

--- a/docs/hdim512_bench.md
+++ b/docs/hdim512_bench.md
@@ -1,9 +1,11 @@
 # Head dim 512 decode benchmark (SM90)
 
+Workload: gemma4-style decode, `head_dim = 512`, `q_len = 1`, `q_head = 8`,
+`k_head = 1`, `batch = 1`, bf16, causal.
+
 ## Setup
 
 - GPU: H200 (sm90a), CUDA 13.0 (nvcc V13.0.88), torch 2.11.0+cu130
-- Shape: `b=1`, `sq=1` (decode), `hq=8 / hkv=1` (GQA), `hd_qk = hd_v = 512`, bf16, causal
 - FA3 numbers produced by:
 
 ```bash

--- a/hopper/epilogue_fwd.hpp
+++ b/hopper/epilogue_fwd.hpp
@@ -21,7 +21,7 @@ namespace flash {
 using namespace cute;
 
 template <class TileShape_MNK_PV_, class ClusterShape_, class Element_, class ArchTag_,
-          int NumEpilogueThreads_, bool Varlen_, bool PackGQA_, bool Split_, bool FP8PermuteCol=false>
+          int NumEpilogueThreads_, bool Varlen_, bool PackGQA_, bool Split_, bool FP8PermuteCol=false, int kHeadDim=0>
 struct CollectiveEpilogueFwd {
 
     using TileShape_MNK_PV = TileShape_MNK_PV_;

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -289,7 +289,14 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             }
             #endif
             #ifndef FLASHATTENTION_DISABLE_HDIM256
-            if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::bfloat16_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+            if (params.d <= 256) {
+                return run_mha_fwd_<Arch, cutlass::bfloat16_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream);
+            }
+            #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                return run_mha_fwd_<Arch, cutlass::bfloat16_t, 512, 512, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream);
+            }
             #endif
         } else {
             #ifndef FLASHATTENTION_DISABLE_FP16
@@ -328,6 +335,11 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::half_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
             #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                return run_mha_fwd_<Arch, cutlass::half_t, 512, 512, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream);
+            }
+            #endif
             #else
             TORCH_CHECK(false, "This flash attention build does not support FP16.");
             #endif
@@ -357,6 +369,9 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
         #endif
         #ifndef FLASHATTENTION_DISABLE_HDIM256
         if (params.d <= 256) { return run_mha_fwd_<90, cutlass::float_e4m3_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+        #endif
+        #ifndef FLASHATTENTION_DISABLE_HDIM512
+        if (params.d <= 512) { return run_mha_fwd_<90, cutlass::float_e4m3_t, 512, 512, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
         #endif
         #else
         TORCH_CHECK(false, "This flash attention build does not support FP8.");
@@ -471,6 +486,9 @@ inline int get_num_splits(Flash_fwd_params const& params) {
 }
 
 inline int get_max_headdim() {
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    return 512;
+    #endif
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     return 256;
     #endif

--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -356,6 +356,9 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::bfloat16_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
             #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) { return run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+            #endif
         } else {
             #ifndef FLASHATTENTION_DISABLE_FP16
             #ifndef FLASHATTENTION_DISABLE_HDIM64
@@ -392,6 +395,9 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #endif
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::half_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+            #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) { return run_mha_fwd_<90, cutlass::half_t, 512, 512, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
             #endif
             #else
             STD_TORCH_CHECK(false, "This flash attention build does not support FP16.");
@@ -536,6 +542,9 @@ inline int get_num_splits(Flash_fwd_params const& params) {
 }
 
 inline int get_max_headdim() {
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    return 512;
+    #endif
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     return 256;
     #endif

--- a/hopper/flash_fwd_kernel_sm90.h
+++ b/hopper/flash_fwd_kernel_sm90.h
@@ -234,6 +234,8 @@ public:
         if constexpr (Use_TMA_KV && !SameHeadDim) {
             pipeline_params_vt.transaction_bytes = CollectiveMainloop::TmaTransactionBytesV;
             if constexpr (LargeHeadDimV) { pipeline_params_vt.num_consumers = NumMmaThreads; }
+        } else if constexpr (Use_TMA_KV) {
+            if constexpr (LargeHeadDimV) { pipeline_params_vt.num_consumers = NumMmaThreads; }
         } else {
             if constexpr (LargeHeadDimV) { pipeline_params_vt.consumer_arv_count = NumMmaThreads; }
         }

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -44,7 +44,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     static constexpr bool MmaPV_is_RS = std::get<2>(kBlockMN_RS_IntraWGOverlap);
     static constexpr bool IntraWGOverlap = std::get<3>(kBlockMN_RS_IntraWGOverlap);
     static constexpr int kNWarps = std::get<2>(kBlockMN_kNWarps_Stages_RS);
-    static constexpr int kStages = Arch >= 90 ? 2 : std::get<3>(kBlockMN_kNWarps_Stages_RS);
+    static constexpr int kStages = Arch >= 90 ? (kHeadDim >= 512 ? 1 : 2) : std::get<3>(kBlockMN_kNWarps_Stages_RS);
     static constexpr bool Q_in_regs = Arch >= 90 ? false : std::get<4>(kBlockMN_kNWarps_Stages_RS);
 
     using TileShape_MNK = cute::Shape<Int<kBlockM>, Int<kBlockN>, Int<kHeadDim>>;
@@ -55,7 +55,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
         flash::CollectiveMainloopFwdSm90<kStages, ClusterShape, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm90, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, HasQv, MmaPV_is_RS, IntraWGOverlap, PackGQA, Split, V_colmajor>,
         flash::CollectiveMainloopFwdSm80<kNWarps, kStages, Q_in_regs, TileShape_MNK, kHeadDimV, Element, float, cutlass::arch::Sm80, Is_causal, Is_local, Has_softcap, Varlen, PagedKVNonTMA, AppendKV, PackGQA, Split>
     >;
-    using CollectiveEpilogue = flash::CollectiveEpilogueFwd<TileShape_MNK_PV, ClusterShape, ElementOut, ArchTag, CollectiveMainloop::NumMmaThreads, Varlen, PackGQA, Split, FP8_TransposeV>;
+    using CollectiveEpilogue = flash::CollectiveEpilogueFwd<TileShape_MNK_PV, ClusterShape, ElementOut, ArchTag, CollectiveMainloop::NumMmaThreads, Varlen, PackGQA, Split, FP8_TransposeV, kHeadDim>;
 
     static constexpr int NumProducerThreads = Arch >= 90 ? CollectiveMainloop::NumProducerThreads : CollectiveMainloop::NumMmaThreads;
     static constexpr bool LPT = Is_causal || Is_local;
@@ -209,7 +209,9 @@ void run_mha_fwd_(Flash_fwd_params &params, cudaStream_t stream) {
             VARLEN_SWITCH(params.cu_seqlens_q || params.cu_seqlens_k || params.seqused_q || params.seqused_k || params.leftpad_k, Varlen, [&] {
                 // Only needed here to decide if we should use cluster
                 static constexpr int kBlockM = Arch >= 90 ? std::get<0>(tile_size_fwd_sm90(kHeadDim, kHeadDimV, Is_causal, Is_local, sizeof(T) /*element_size*/, V_colmajor, PagedKVNonTMA, Has_softcap)) : 128;
-                static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen;
+                // Disable cluster when HeadDim == 512
+                static constexpr bool LargeHeadDimV_SameHeadDim = (kHeadDimV > 256) && (kHeadDim == kHeadDimV);
+                static constexpr bool Enable_cluster = Arch == 90 && (sizeof(T) == 2 ? (kHeadDim >= 128) : (kHeadDim == 192)) && !Is_causal && !Is_local && !Split && !PagedKVNonTMA && !Varlen && !LargeHeadDimV_SameHeadDim;
                 BOOL_SWITCH(params.qv_ptr, HasQV_, [&] {
                     static constexpr bool HasQv = HasQV_ && Arch == 90 && !Is_FP8 && kHeadDim == 64 && kHeadDimV >= 256;
                     APPENDKV_SWITCH(params.knew_ptr, AppendKV, [&] {

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_packgqa_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, false, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_packgqa_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, true, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_split_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_split_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_packgqa_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, false, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_packgqa_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, true, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_split_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_split_softcap_sm90.cu
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+// Splitting the different template instantiations to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -1384,9 +1384,11 @@ struct CollectiveMainloopFwdSm90 {
         Layout warp_group_thread_layout = make_layout(make_shape(Int<MmaWarpGroups>{}),
                                                       make_stride(Int<cutlass::NumThreadsPerWarpGroup>{}));
 
-        int warp_group_idx = __shfl_sync(0xFFFFFFFF, thread_idx / cutlass::NumThreadsPerWarpGroup, 0);
+        // With LargeHeadDimV the PV mma runs on WG2+, so map the global thread index
+        // back to a local warpgroup index for partitioning.
+        int mma_wg_idx = (thread_idx % NumMmaThreads) / cutlass::NumThreadsPerWarpGroup;
         TiledMmaPV tiled_mma_pv;
-        auto wg_mma_pv = tiled_mma_pv.get_slice(warp_group_thread_layout(warp_group_idx));
+        auto wg_mma_pv = tiled_mma_pv.get_slice(warp_group_thread_layout(mma_wg_idx));
 
         // Allocate "fragments/descriptors"
         Tensor tOrV = wg_mma_pv.partition_fragment_B(sV);

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -64,6 +64,7 @@ DISABLE_HDIM96 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM96", "FALSE") == "TRUE"
 DISABLE_HDIM128 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM128", "FALSE") == "TRUE"
 DISABLE_HDIM192 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM192", "FALSE") == "TRUE"
 DISABLE_HDIM256 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM256", "FALSE") == "TRUE"
+DISABLE_HDIM512 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM512", "FALSE") == "TRUE"
 DISABLE_SM8x = os.getenv("FLASH_ATTENTION_DISABLE_SM80", "FALSE") == "TRUE"
 
 ENABLE_VCOLMAJOR = os.getenv("FLASH_ATTENTION_ENABLE_VCOLMAJOR", "FALSE") == "TRUE"
@@ -118,6 +119,7 @@ def create_build_config_file():
             "FLASHATTENTION_DISABLE_HDIM128": DISABLE_HDIM128,
             "FLASHATTENTION_DISABLE_HDIM192": DISABLE_HDIM192,
             "FLASHATTENTION_DISABLE_HDIM256": DISABLE_HDIM256,
+            "FLASHATTENTION_DISABLE_HDIM512": DISABLE_HDIM512,
             "FLASHATTENTION_DISABLE_SM8x": DISABLE_SM8x,
             "FLASHATTENTION_ENABLE_VCOLMAJOR": ENABLE_VCOLMAJOR,
             "FLASH_ATTENTION_DISABLE_HDIMDIFF64": DISABLE_HDIMDIFF64,
@@ -445,7 +447,9 @@ ext_modules = []
 # We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
 # files included in the source distribution, in case the user compiles from source.
 if not USE_TRITON_ROCM:
-    subprocess.run(["git", "submodule", "update", "--init", "../csrc/cutlass"])
+    cutlass_path = Path(this_dir) / ".." / "csrc" / "cutlass"
+    if not cutlass_path.exists():
+        subprocess.run(["git", "submodule", "update", "--init", "../csrc/cutlass"])
 
 if not SKIP_CUDA_BUILD:
     print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))
@@ -498,10 +502,11 @@ if not SKIP_CUDA_BUILD:
         nvcc_path_new = os.path.join(ctk_path_new, f"nvcc{exe_extension}")
         # Need to append to path otherwise nvcc can't find cicc in nvvm/bin/cicc
         # nvcc 12.8 seems to hard-code looking for cicc in ../nvvm/bin/cicc
-        os.environ["PATH"] = ctk_path_new + os.pathsep + os.environ["PATH"]
-        os.environ["PYTORCH_NVCC"] = nvcc_path_new
-        # Make nvcc executable, sometimes after the copy it loses its permissions
-        os.chmod(nvcc_path_new, os.stat(nvcc_path_new).st_mode | stat.S_IEXEC)
+        if os.path.exists(nvcc_path_new):
+            os.environ["PATH"] = ctk_path_new + os.pathsep + os.environ["PATH"]
+            os.environ["PYTORCH_NVCC"] = nvcc_path_new
+            # Make nvcc executable, sometimes after the copy it loses its permissions
+            os.chmod(nvcc_path_new, os.stat(nvcc_path_new).st_mode | stat.S_IEXEC)
 
     cc_flag = []
     cc_flag.append("-gencode")
@@ -533,6 +538,7 @@ if not SKIP_CUDA_BUILD:
         + (["-DFLASHATTENTION_DISABLE_HDIM128"] if DISABLE_HDIM128 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIM192"] if DISABLE_HDIM192 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIM256"] if DISABLE_HDIM256 else [])
+        + (["-DFLASHATTENTION_DISABLE_HDIM512"] if DISABLE_HDIM512 else [])
         + (["-DFLASHATTENTION_DISABLE_SM8x"] if DISABLE_SM8x else [])
         + (["-DFLASHATTENTION_ENABLE_VCOLMAJOR"] if ENABLE_VCOLMAJOR else [])
         + (["-DFLASHATTENTION_DISABLE_HDIMDIFF64"] if DISABLE_HDIMDIFF64 else [])
@@ -553,7 +559,7 @@ if not SKIP_CUDA_BUILD:
     )
     # build will now explode with this compilation grouping given all our templating
     # HEAD_DIMENSIONS_FWD = ["all", "diff"]
-    HEAD_DIMENSIONS_FWD = HEAD_DIMENSIONS_BWD
+    HEAD_DIMENSIONS_FWD = HEAD_DIMENSIONS_BWD + ([512] if not DISABLE_HDIM512 else [])
     HEAD_DIMENSIONS_DIFF64_FWD = (
         []
         + (["64_256"] if not DISABLE_HDIMDIFF64 else [])
@@ -575,7 +581,8 @@ if not SKIP_CUDA_BUILD:
     # We already always hard-code PackGQA=true for Sm9x if PagedKV or Split
     sources_fwd_sm90 = [f"instantiations/flash_fwd_hdim{hdim}_{dtype}{paged}{split}{softcap}{packgqa}_sm90.cu"
                         for hdim, dtype, split, paged, softcap, packgqa in itertools.product(HEAD_DIMENSIONS_FWD, DTYPE_FWD_SM90, SPLIT, PAGEDKV, SOFTCAP, PACKGQA)
-                        if not (packgqa and (paged or split))]
+                        if not (packgqa and (paged or split))
+                        and not (hdim == 512 and dtype == "e4m3")]  # hdim512 + e4m3 not supported
     if not DISABLE_HDIMDIFF64:
         sources_fwd_sm90 += [f"instantiations/flash_fwd_hdim{hdim}_{dtype}{paged}{split}{softcap}{packgqa}_sm90.cu"
                              for hdim, dtype, split, paged, softcap, packgqa in itertools.product(HEAD_DIMENSIONS_DIFF64_FWD, HALF_DTYPE_FWD_SM90, SPLIT, PAGEDKV, SOFTCAP, PACKGQA)

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -35,8 +35,12 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
             // 128 x 192 hits the limit of smem if MmaPV_is_RS, 128 x 144 hits the limit if !MmaPV_is_RS
         } else if (headdim <= 192) {
             return {128, paged_kv_non_TMA || is_local ? 96 : (headdim_v <= 128 ? 128 : 112), true, true};  // 128 x 112 hits the limit of smem
-        } else {
+        } else if (headdim <= 256) {
             return {128, is_local ? 64 : 80, true, true};  // 128 x 80 hits the limit of smem
+        } else {
+            // 64 x 64 -> Q + K + V/O = 64 + 64 + 64 = 192KB, 64 x 80 exceeds the 227KB smem limit.
+            // MmaPV must be SS since LargeHeadDimV splits the PV mma across 2 warpgroups.
+            return {64, 64, false, false};
         }
     } else {
         if (headdim <= 64) {
@@ -47,8 +51,10 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
             return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
         } else if (headdim <= 192) {
             return {128, (paged_kv_non_TMA || softcap) && is_local ? 128 : 160, true, true};
-        } else {
+        } else if (headdim <= 256) {
             return {128, is_local ? 64 : 128, true, !paged_kv_non_TMA};  // PagedKV uses more registers so we disabled IntraWGOverlap
+        } else {
+            return {64, 32, false, false};  // headdim 512 needs a smaller tile to fit in smem
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -378,6 +378,10 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_hdim512_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_hdim512_bf16_causal_sm80.cu",
             ],
             extra_compile_args={
                 "cxx": compiler_c17_flag,

--- a/tests/hopper/bench_fa2_fa3_hd512.py
+++ b/tests/hopper/bench_fa2_fa3_hd512.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+"""FA2 vs FA3 decode benchmark (hd512 by default), single script.
+
+- Both go through flash_attn_with_kvcache + cache_seqlens (fair comparison).
+- Each measurement is preceded by a correctness check against an fp32 reference,
+  so a silently-wrong "fast" path can never win.
+- Pick an idle GPU first (shared box!):  CUDA_VISIBLE_DEVICES=1 python bench_fa2_fa3_hd512.py
+
+Usage examples:
+    python bench_fa2_fa3_hd512.py                      # default: bf16, hd512
+    python bench_fa2_fa3_hd512.py --dtype fp16 --hd 128
+    python bench_fa2_fa3_hd512.py --ns 0 16 --iters 100
+"""
+import argparse
+import math
+
+import torch
+
+try:
+    import flash_attn as fa2
+    from flash_attn import flash_attn_with_kvcache as fa2_kv
+except ImportError as e:
+    fa2, fa2_kv = None, None
+    fa2_import_error = e
+import flash_attn_interface as fa3
+from flash_attn_interface import flash_attn_with_kvcache as fa3_kv
+
+
+def ref_attn(q, k, v, causal):
+    """fp32 reference, GQA-aware. Returns (ref, lp_ref_err_bound)."""
+    b, sq, hq, d = q.shape
+    sk, hkv = k.shape[1], k.shape[2]
+    kr = k.repeat_interleave(hq // hkv, dim=2)
+    vr = v.repeat_interleave(hq // hkv, dim=2)
+    if causal:
+        i = torch.arange(sq, device=q.device).view(-1, 1)
+        j = torch.arange(sk, device=q.device).view(1, -1)
+        mask = j > (sk - sq) + i
+    s = torch.einsum("bqhd,bkhd->bhqk", q.float(), kr.float()) / math.sqrt(d)
+    if causal:
+        s.masked_fill_(mask, float("-inf"))
+    ref = torch.einsum("bhqk,bkhd->bqhd", s.softmax(-1), vr.float())
+    # same computation but with the P matrix rounded to the low precision dtype,
+    # which bounds the error any correct low-precision kernel can legitimately have
+    s2 = torch.einsum("bqhd,bkhd->bhqk", q, kr).float() / math.sqrt(d)
+    if causal:
+        s2.masked_fill_(mask, float("-inf"))
+    lp = torch.einsum("bhqk,bkhd->bqhd", s2.softmax(-1).to(q.dtype).float(), vr.float())
+    return ref, (lp - ref).abs().max().item()
+
+
+def out_of(x):
+    return x[0] if isinstance(x, tuple) else x
+
+
+def time_fn(fn, iters, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start, end = torch.cuda.Event(True), torch.cuda.Event(True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms
+
+
+def graph_time_fn(fn, iters, warmup=10):
+    """Capture one call into a CUDA Graph and time replays (no host launch overhead)."""
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            fn()
+    torch.cuda.current_stream().wait_stream(s)
+    with torch.cuda.graph(g):
+        fn()
+    for _ in range(warmup):
+        g.replay()
+    torch.cuda.synchronize()
+    start, end = torch.cuda.Event(True), torch.cuda.Event(True)
+    start.record()
+    for _ in range(iters):
+        g.replay()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms
+
+
+def make_l2_flush(mbytes):
+    """A copy big enough to evict L2, so the timed kernel starts cold -- what a
+    real model sees, since other layers stream through L2 between two visits of
+    the same attention layer."""
+    src = torch.empty((mbytes << 20) // 2, dtype=torch.bfloat16, device="cuda")
+    dst = torch.empty_like(src)
+    return lambda: dst.copy_(src)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--hd", type=int, default=512, help="QK head dim")
+    p.add_argument("--hdv", type=int, default=None,
+                   help="V head dim (default: same as --hd). If different, only FA3 runs (FA2 requires K/V same dim)")
+    p.add_argument("--dtype", choices=["bf16", "fp16"], default="bf16")
+    p.add_argument("--hq", type=int, default=8)
+    p.add_argument("--hkv", type=int, default=1)
+    p.add_argument("--sq", type=int, default=1)
+    p.add_argument("--causal", type=int, choices=[0, 1], default=1,
+                   help="1=causal (default), 0=non-causal; only matters when sq>1 given full cache_seqlens")
+    p.add_argument("--graph", type=int, choices=[0, 1], default=0,
+                   help="1 = time CUDA Graph replays (no host launch overhead); correctness still checked eagerly")
+    p.add_argument("--page-size", type=int, default=0,
+                   help="paged KV page size; 0 = contiguous cache (no paging). FA2 uses block_table, FA3 uses page_table")
+    p.add_argument("--pool-tokens", dest="pool_tokens", type=int, default=0,
+                   help="paged KV pool size in tokens (needs --page-size>0). The "
+                   "request's pages are scattered over this pool, like a server's "
+                   "token_to_kv_pool. 0 = tight pool (pages contiguous, L2-friendly)")
+    p.add_argument("--l2-flush-mb", dest="l2_flush_mb", type=int, default=0,
+                   help="MB copied inside the timed region to evict L2 before the "
+                   "kernel, then subtracted out. 0 = L2 stays warm (optimistic for "
+                   "decode shapes whose KV fits in the 50MB L2)")
+    p.add_argument("--ns", type=int, nargs="+", default=[0], help="num_splits values (0=auto)")
+    p.add_argument("--iters", type=int, default=50)
+    p.add_argument("--cases", type=str, default="1x32768,4x32768,32x4096",
+                   help="comma-separated bxcache, e.g. 1x32768,32x4096")
+    p.add_argument("--dump", type=int, default=0, metavar="N",
+                   help="print first N output elements per impl side-by-side with the fp32 gold (0=off)")
+    args = p.parse_args()
+
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    hdv = args.hdv if args.hdv is not None else args.hd
+    run_fa2 = hdv == args.hd
+    fa2_skip_reason = "hd_qk != hd_v: FA2 skipped (requires K/V same head dim), FA3 only"
+    if run_fa2 and fa2_kv is None:
+        run_fa2 = False
+        fa2_skip_reason = f"FA2 not importable ({fa2_import_error}): FA3 only"
+    if run_fa2 and args.page_size > 0 and args.page_size % 256 != 0:
+        run_fa2 = False
+        fa2_skip_reason = f"page_size={args.page_size} not a multiple of 256: FA2 skipped (its paged KV requires %256==0), FA3 only"
+    causal = bool(args.causal)
+    timer = graph_time_fn if args.graph else time_fn
+    flush = make_l2_flush(args.l2_flush_mb) if args.l2_flush_mb else None
+
+    def timed(fn, iters):
+        """Kernel time with a cold L2: time(flush + kernel) - time(flush)."""
+        if flush is None:
+            return timer(fn, iters)
+        base = timer(flush, iters)
+        return timer(lambda: (flush(), fn()), iters) - base
+
+    cases = [tuple(map(int, c.split("x"))) for c in args.cases.split(",")]
+    dev = torch.cuda.current_device()
+    print(f"device: {torch.cuda.get_device_name(dev)} (cuda:{dev})")
+    print(f"fa2: {fa2.__file__ if fa2 is not None else 'n/a'} ({getattr(fa2, '__version__', '?')})")
+    print(f"fa3: {fa3.__file__}")
+    print(f"config: {args.dtype} hd_qk={args.hd} hd_v={hdv} hq{args.hq}/hkv{args.hkv} sq{args.sq} causal={causal} graph={bool(args.graph)} page_size={args.page_size} iters={args.iters}")
+    print(f"pool_tokens={args.pool_tokens} l2_flush={args.l2_flush_mb}MB")
+    if not run_fa2:
+        print(fa2_skip_reason)
+    torch.manual_seed(0)
+
+    header = f"{'case':>16} {'ns':>4} {'FA2 ms':>9} {'FA2 GB/s':>9} {'FA3 ms':>9} {'FA3 GB/s':>9} {'FA3/FA2':>8}"
+    print("\n" + header)
+    print("-" * len(header))
+    all_ok = True
+    for b, cache in cases:
+        q = torch.randn(b, args.sq, args.hq, args.hd, dtype=dtype, device="cuda") / 3
+        k = torch.randn(b, cache, args.hkv, args.hd, dtype=dtype, device="cuda") / 3
+        v = torch.randn(b, cache, args.hkv, hdv, dtype=dtype, device="cuda") / 3
+        cs = torch.full((b,), cache, dtype=torch.int32, device="cuda")
+        ref, lp_err = ref_attn(q, k, v, causal)
+        if args.page_size > 0:
+            page = args.page_size
+            npp = (cache + page - 1) // page
+            need = b * npp
+            pool_pages = max(need, args.pool_tokens // page)
+            k_in = torch.zeros(pool_pages, page, args.hkv, args.hd, dtype=dtype, device="cuda")
+            v_in = torch.zeros(pool_pages, page, args.hkv, hdv, dtype=dtype, device="cuda")
+            if pool_pages > need:
+                # scattered slots inside a big pool, like a server's KV allocator
+                ids = torch.randperm(pool_pages, device="cuda")[:need].to(torch.int32)
+            else:
+                ids = torch.arange(need, dtype=torch.int32, device="cuda")
+            kp = torch.zeros(b, npp * page, args.hkv, args.hd, dtype=dtype, device="cuda")
+            vp = torch.zeros(b, npp * page, args.hkv, hdv, dtype=dtype, device="cuda")
+            kp[:, :cache] = k
+            vp[:, :cache] = v
+            k_in[ids.long()] = kp.view(need, page, args.hkv, args.hd)
+            v_in[ids.long()] = vp.view(need, page, args.hkv, hdv)
+            del kp, vp
+            pt = ids.reshape(b, npp)
+            extra = {"FA2": {"block_table": pt}, "FA3": {"page_table": pt}}
+        else:
+            k_in, v_in = k, v
+            extra = {"FA2": {}, "FA3": {}}
+        tol = max(3 * lp_err, 1e-3) + 1e-5
+        # KV bytes read (K+V) once per token step
+        kv_bytes = b * cache * args.hkv * (args.hd + hdv) * q.element_size()
+
+        impls = [("FA2", fa2_kv), ("FA3", fa3_kv)] if run_fa2 else [("FA3", fa3_kv)]
+        for ns in args.ns:
+            times = {}
+            cols = {}
+            for name, fn in impls:
+                out = out_of(fn(q, k_in, v_in, cache_seqlens=cs, causal=causal, num_splits=ns, **extra[name]))
+                err = (out.float() - ref).abs().max().item()
+                if not (torch.isfinite(out.float()).all().item() and err <= tol):
+                    all_ok = False
+                    print(f"FAIL correctness {name} b={b} cache={cache} ns={ns} err={err:.2e} tol={tol:.2e}")
+                if args.dump > 0:
+                    g = ref.flatten().float()
+                    o = out.flatten().float()
+                    n = min(args.dump, g.numel())
+                    amax = (o - g).abs().argmax().item()
+                    print(f"\n[dump] {name} b={b} cache={cache} ns={ns}  err={err:.2e} tol={tol:.2e}  (showing {n}/{g.numel()} elems)")
+                    print(f"       {'idx':>8} {'gold':>14} {'out':>14} {'abs_diff':>12}")
+                    for i in range(n):
+                        print(f"       {i:>8} {g[i].item():>14.6f} {o[i].item():>14.6f} {abs(o[i]-g[i]).item():>12.2e}")
+                    print(f"       {'^max@'+str(amax):>8} {g[amax].item():>14.6f} {o[amax].item():>14.6f} {abs(o[amax]-g[amax]).item():>12.2e}")
+                ms = timed(lambda: fn(q, k_in, v_in, cache_seqlens=cs, causal=causal, num_splits=ns, **extra[name]), args.iters)
+                times[name] = ms
+                cols[name] = f" {ms:>9.4f} {kv_bytes / (ms * 1e-3) / 1e9:>9.0f}"
+            fa2_col = cols.get("FA2", f" {'n/a':>9} {'n/a':>9}")
+            ratio = f" {times['FA2'] / times['FA3']:>7.2f}x" if run_fa2 else f" {'n/a':>8}"
+            print(f"{f'b={b} cache={cache}':>16} {ns:>4}{fa2_col}{cols['FA3']}{ratio}")
+    print("\nall correctness checks PASS" if all_ok else "\nSOME CORRECTNESS CHECKS FAILED — timings above are not comparable!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hopper/verify_fa3_causal_decode_prefill.py
+++ b/tests/hopper/verify_fa3_causal_decode_prefill.py
@@ -1,0 +1,61 @@
+import torch, math
+from flash_attn_interface import flash_attn_func, flash_attn_with_kvcache
+
+def unwrap(x):
+    return x[0] if isinstance(x, tuple) else x
+
+def ref_attn(q, k, v, causal):
+    # fp32 reference, bottom-right aligned causal (FA semantics)
+    b, sq, hq, d = q.shape
+    sk, hkv = k.shape[1], k.shape[2]
+    kr = k.repeat_interleave(hq // hkv, dim=2)
+    vr = v.repeat_interleave(hq // hkv, dim=2)
+    s = torch.einsum("bqhd,bkhd->bhqk", q.float(), kr.float()) / math.sqrt(d)
+    if causal:
+        i = torch.arange(sq, device=q.device).view(-1, 1)
+        j = torch.arange(sk, device=q.device).view(1, -1)
+        s.masked_fill_(j > (sk - sq) + i, float("-inf"))
+    p = s.softmax(-1)
+    o = torch.einsum("bhqk,bkhd->bqhd", p, vr.float())
+    # low-precision reference for tolerance scaling
+    s2 = torch.einsum("bqhd,bkhd->bhqk", q, kr).float() / math.sqrt(d)
+    if causal:
+        s2.masked_fill_(j > (sk - sq) + i, float("-inf"))
+    o2 = torch.einsum("bhqk,bkhd->bqhd", s2.softmax(-1).to(q.dtype).float(), vr.float())
+    return o, o2
+
+def check(name, out, ref, ref_lp):
+    err = (out.float() - ref).abs().max().item()
+    err_lp = (ref_lp - ref).abs().max().item()
+    ok = torch.isfinite(out.float()).all().item() and err <= max(3 * err_lp, 1e-3) + 1e-5
+    print(f"{'PASS' if ok else 'FAIL'}  {name}  err={err:.2e} (lp_ref={err_lp:.2e})")
+    return ok
+
+fails = 0
+torch.manual_seed(0)
+for dtype in (torch.bfloat16, torch.float16):
+    tag = "bf16" if dtype == torch.bfloat16 else "fp16"
+    for hd in (512, 128):
+        # ---- causal decode: seqlen_q > 1, KV cache ----
+        for sq in (1, 2, 5, 17, 32):
+            for b, cache in ((1, 33), (2, 1000), (3, 4097)):
+                hq, hkv = 8, 1
+                q = torch.randn(b, sq, hq, hd, dtype=dtype, device="cuda") / 3
+                k = torch.randn(b, cache + 64, hkv, hd, dtype=dtype, device="cuda") / 3
+                v = torch.randn_like(k)
+                cs = torch.full((b,), cache, dtype=torch.int32, device="cuda")
+                ref, ref_lp = ref_attn(q, k[:, :cache], v[:, :cache], causal=True)
+                for ns in (1, 2, 8, 16, 0):
+                    out = unwrap(flash_attn_with_kvcache(q, k, v, cache_seqlens=cs, causal=True, num_splits=ns))
+                    fails += not check(f"{tag} hd{hd} decode  sq={sq:2d} b={b} cache={cache:4d} ns={ns:2d}", out, ref, ref_lp)
+        # ---- causal prefill: flash_attn_func, seqlen_q == seqlen_k ----
+        for b, s in ((1, 128), (2, 517), (1, 2048)):
+            for hq, hkv in ((8, 1), (8, 8)):
+                q = torch.randn(b, s, hq, hd, dtype=dtype, device="cuda") / 3
+                k = torch.randn(b, s, hkv, hd, dtype=dtype, device="cuda") / 3
+                v = torch.randn_like(k)
+                ref, ref_lp = ref_attn(q, k, v, causal=True)
+                out = unwrap(flash_attn_func(q, k, v, causal=True))
+                fails += not check(f"{tag} hd{hd} prefill sq=sk={s:4d} b={b} hq/hkv={hq}/{hkv}", out, ref, ref_lp)
+print("=" * 60)
+print("ALL PASS" if fails == 0 else f"{fails} FAILURES")


### PR DESCRIPTION
## What

Adds forward support for QK/V head dim 512:

- FA2 (`csrc/`): split-KV hdim512 instantiations for bf16/fp16 (causal and
  non-causal) on SM80, plus `kernel_traits.h` / `static_switch.h` /
  launch-template plumbing.
- FA3 (`hopper/`): 20 hdim512 SM90 forward instantiations (bf16/fp16 x
  split / paged / softcap / packgqa), `flash_api*.cpp` dispatch,
  `epilogue_fwd.hpp` and `tile_size.h` updates. hdim512 + e4m3 is not
  supported and is excluded in `setup.py`.
- Build: hdim512 is on by default, gated by `FLASH_ATTENTION_DISABLE_HDIM512=TRUE`.

## Tests

On H200 (sm90a), CUDA 13.0, torch 2.11.0+cu130:

- `python tests/hopper/verify_fa3_causal_decode_prefill.py` → `ALL PASS`
  (decode and prefill, fp16/bf16, hd128 and hd512, MHA/GQA).
- No-regression build with hdim512 disabled: full `hopper` extension builds
  clean with `FLASH_ATTENTION_DISABLE_HDIM512=TRUE`, so the shared header
  changes do not affect other head dims.
- Decode performance: `docs/hdim512_bench.md`. At `head_dim=512 q_len=1
  q_head=8 k_head=1 batch=1` bf16 causal, FA3 is 3.0x faster than the
  sglang-triton baseline at cache=2048 and 17.8x at cache=32768; it is at
  parity or slightly behind for cache <= 512 where launch overhead dominates.